### PR TITLE
fix: send Zotero write payloads as JSON arrays

### DIFF
--- a/src/scansci_pdf/zotero.py
+++ b/src/scansci_pdf/zotero.py
@@ -64,17 +64,17 @@ def push_to_zotero(
         resp = requests.post(
             f"{base_url}/items",
             headers=headers,
-            json={"items": [item_data]},
+            json=[item_data],
             timeout=30,
         )
         if resp.status_code not in (200, 201):
             return {"success": False, "error": f"Zotero API error: {resp.status_code}"}
 
         result = resp.json()
-        if not result.get("successful"):
+        if not (result.get("success") or result.get("successful")):
             return {"success": False, "error": "No successful items"}
 
-        zotero_key = list(result["successful"].keys())[0] if result["successful"] else None
+        zotero_key = _created_object_key(result)
         if not zotero_key:
             return {"success": False, "error": "No key returned"}
 
@@ -164,7 +164,7 @@ def _upload_attachment(
         resp = requests.post(
             f"{base_url}/items",
             headers=headers,
-            json={"items": [attachment_data]},
+            json=[attachment_data],
             timeout=30,
         )
         if resp.status_code not in (200, 201):
@@ -172,7 +172,7 @@ def _upload_attachment(
             return False
 
         result = resp.json()
-        att_key = list(result.get("successful", {}).keys())[0] if result.get("successful") else None
+        att_key = _created_object_key(result)
         if not att_key:
             return False
 
@@ -200,3 +200,23 @@ def _upload_attachment(
     except Exception as e:
         log.warning(f"Zotero: attachment error: {e}")
         return False
+
+
+def _created_object_key(result: dict[str, Any]) -> str | None:
+    """Extract the Zotero object key from a write response."""
+    successful = result.get("successful") or result.get("success") or {}
+    if not successful:
+        return None
+
+    saved_object = next(iter(successful.values()))
+    if isinstance(saved_object, str):
+        return saved_object
+    if isinstance(saved_object, dict):
+        key = saved_object.get("key")
+        if isinstance(key, str):
+            return key
+        data = saved_object.get("data", {})
+        if isinstance(data, dict) and isinstance(data.get("key"), str):
+            return data["key"]
+
+    return None

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from scansci_pdf import zotero
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_push_to_zotero_posts_item_as_raw_json_array(monkeypatch):
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse(payload={"success": {"0": "ITEMKEY"}})
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    result = zotero.push_to_zotero(
+        doi="10.1234/example",
+        pdf_path=None,
+        config={
+            "zotero_api_key": "test-key",
+            "zotero_library_type": "user",
+            "zotero_library_id": "123456",
+        },
+    )
+
+    assert result == {"success": True, "zotero_key": "ITEMKEY"}
+    assert calls[0][0] == "https://api.zotero.org/users/123456/items"
+    assert isinstance(calls[0][1]["json"], list)
+    assert calls[0][1]["json"][0]["DOI"] == "10.1234/example"
+
+
+def test_upload_attachment_posts_item_as_raw_json_array(monkeypatch, tmp_path):
+    calls = []
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs))
+        if url.endswith("/items"):
+            return FakeResponse(payload={"success": {"0": "ATTKEY"}})
+        return FakeResponse(status_code=204)
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    ok = zotero._upload_attachment(
+        base_url="https://api.zotero.org/users/123456",
+        headers={"Zotero-API-Key": "test-key", "Content-Type": "application/json"},
+        parent_key="PARENTKEY",
+        pdf_path=Path(pdf_path),
+    )
+
+    assert ok is True
+    assert calls[0][0] == "https://api.zotero.org/users/123456/items"
+    assert isinstance(calls[0][1]["json"], list)
+    assert calls[0][1]["json"][0]["parentItem"] == "PARENTKEY"
+    assert calls[1][0] == "https://api.zotero.org/users/123456/items/ATTKEY/file"


### PR DESCRIPTION
Fixes Zotero push failures caused by wrapping item creation payloads in `{ "items": [...] }`.

Zotero Web API v3 write requests for `POST /items` expect a raw JSON array. With the previous payload shape, Zotero rejects the request with:

`Uploaded data must be a JSON array`

This PR changes both top-level item creation and attachment item creation to send raw arrays. It also parses the created object key from Zotero write responses, so PDF attachment uploads target the created item key instead of the write-array index.

Reference:
https://www.zotero.org/support/dev/web_api/v3/write_requests

Tested:
- `python -m pytest tests/test_zotero.py -q --basetemp .pytest-tmp` -> `2 passed`

Note: full `python -m pytest -q --basetemp .pytest-tmp` still fails on the existing `tests/test_sso_publishers.py::test_publisher` fixture setup issue (`fixture 'publisher' not found`), which is unrelated to this Zotero change.