### PR TITLE
Fix auto_setup Sci-Hub probe crash: 'int' object has no attribute 'get'

### DIFF
--- a/src/scansci_pdf/server.py
+++ b/src/scansci_pdf/server.py
@@ -344,7 +344,8 @@ def scansci_pdf_auto_setup() -> str:
         set_probe_timestamp(config_copy, timestamp=0)
         _probe_scihub_domains(config_copy)
         stats = load_stats(config_copy)
-        reachable = [d for d, s in stats.items() if s.get("reachable") and not d.startswith("_")]
+        reachable = [d for d, s in stats.items()
+                     if not d.startswith("_") and isinstance(s, dict) and s.get("reachable")]
         report["actions"].append(f"Sci-Hub: {len(reachable)} domains reachable")
         report["status"]["scihub_domains"] = reachable[:5]
     except Exception as e:


### PR DESCRIPTION
## Summary

`scansci_pdf_auto_setup` always reports a Sci-Hub probe failure even though the probe itself completes successfully:

```
"Sci-Hub probe error: 'int' object has no attribute 'get'"
```

The domain probe runs fine — the crash is in the **result-summarization line** that counts reachable domains.

## Root cause

`load_stats()` (in `domain_db.py`) returns per-domain dicts **plus** a metadata entry `_last_probe`, whose value is an `int` timestamp:

```python
# domain_db.py
stats["_last_probe"] = int(m["value"])
```

In `server.py` (`scansci_pdf_auto_setup`), the summary comprehension evaluates `s.get("reachable")` **before** the `_`-prefix guard:

```python
# server.py (before)
reachable = [d for d, s in stats.items() if s.get("reachable") and not d.startswith("_")]
```

Because Python evaluates the left operand of `and` first, for the `_last_probe` key `s` is an `int`, so `s.get(...)` raises `'int' object has no attribute 'get'` before `not d.startswith("_")` ever runs.

## Fix

Reorder the conditions so the `_`-prefixed metadata keys are filtered out first (short-circuit), and add an `isinstance(s, dict)` guard for robustness:

```python
reachable = [d for d, s in stats.items()
             if not d.startswith("_") and isinstance(s, dict) and s.get("reachable")]
```

## Verification

With the patch applied, the probe + summary runs cleanly:

```
OK, reachable domains: 4
['https://sci-hub.st', 'https://sci-hub.ru', 'https://sci-hub.ee', 'https://sci-hub.41610.org']
```

`scansci_pdf_auto_setup` now reports e.g. `Sci-Hub: 4 domains reachable` instead of the error.

## Environment

- scansci-pdf 1.5.0
- Windows 10, Python (uv-managed venv)
