### PR TITLE
fix: cleanup orphan temp files after parallel source race

### DIFF
--- a/src/scansci_pdf/sources/__init__.py
+++ b/src/scansci_pdf/sources/__init__.py
@@ -457,7 +457,7 @@ def _run_tiers_parallel(
 
         log.info(f"   All sources failed")
     finally:
-        pool.shutdown(wait=False)
+        pool.shutdown(wait=True, cancel_futures=True)
         # Cleanup temp files
         for _, other_path in futures.values():
             if other_path != output_path and other_path.exists():


### PR DESCRIPTION
## Problem

When downloading a single paper with `strategy="fastest"`, the parallel racing engine spawns threads for all 13+ sources. Each source writes to a temp file like `DOI_SourceName.pdf`. The first winner gets renamed to `AuthorYear_Title.pdf`.

However, `pool.shutdown(wait=False)` in the `finally` block does NOT wait for running threads. The cleanup loop runs immediately, removing whatever temp files exist at that moment — but slower sources that finish **after** cleanup leave behind orphaned `_SourceName.pdf` files.

**Result**: 1 download = 7 files on disk (1 correctly renamed + 6 orphans).

## Fix

One-line change in `src/scansci_pdf/sources/__init__.py`:

```python
# Before
pool.shutdown(wait=False)

# After
pool.shutdown(wait=True, cancel_futures=True)
```

- `cancel_futures=True` — cancels pending (not-yet-started) thread futures, so no new downloads begin after the winner is chosen
- `wait=True` — ensures all currently-running threads complete before the cleanup loop runs
- Cleanup then reliably removes ALL temp files

## Verification

Tested with arXiv ID `2402.03300` — single file in output directory ✓ (previously 3-7 files).