### PR TITLE
[codex] Improve Elsevier API full-text retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,71 +9,186 @@
   <a href="https://modelcontextprotocol.io"><img alt="MCP compatible" src="https://img.shields.io/badge/MCP-compatible-green"></a>
 </p>
 
-ScanSci PDF 是一个用于获取学术论文 PDF 的项目，提供 Python 包、命令行工具 和 MCP 服务，并把官方 OA 渠道、灰色渠道（Sci-Hub/LibGen/SciBban）和机构渠道（WebVPN/CARSI/EZProxy/浏览器 SSO）组织到同一套并行竞速与回退流程中。
+# ScanSci PDF
 
----
+ScanSci PDF 是一个面向研究者和学生的论文 PDF 下载工具。给它 DOI、arXiv ID 或论文列表，它会自动尝试开放获取、出版商接口、机构访问和浏览器登录等路径，尽量把可合法访问的全文 PDF 保存到本地。
 
-## 项目范围
+它适合这些场景：
 
-- **多入口使用** — 可作为 Python 包、`scansci-pdf` 命令行工具、浏览器 Web UI 或 MCP 服务使用
-- **开放/官方渠道** — 出版商直链、arXiv、Unpaywall、OpenAlex、Semantic Scholar、DOAJ、EuropePMC、CORE、PMC 等
-- **灰色渠道** — Sci-Hub、LibGen、SciBban 等作为开放源失败或网络受限时的候选源，可结合 Tor 与 CloakBrowser
-- **机构渠道** — 100+ 高校 WebVPN、CARSI、EZProxy、浏览器 SSO，用于有合法机构账号的付费墙访问，CAS/SSO 密码不经过工具
-- **浏览器流程** — 可选 CloakBrowser 处理 Cloudflare/CAPTCHA/SSO、持久化 profile 和出版商页面下载
-- **批量与元数据** — 支持 APA 引文、BibTeX、DOI 列表解析，批量下载、自动重命名、BibTeX/RIS/EndNote 引文导出
-- **诊断与配置** — 检查依赖、数据源延迟、代理、Tor、浏览器状态，并给出修复建议
+- 下载单篇论文或批量 DOI 列表
+- 搜索论文并获取 DOI、BibTeX、RIS、EndNote 引文
+- 用学校账号、WebVPN、CARSI、EZProxy 或浏览器 SSO 访问订阅论文
+- 为 Elsevier / ScienceDirect 配置 API Key，快速获取全文 PDF
+- 在 Agent / MCP 客户端中把论文下载能力交给 AI 助手调用
+
+使用任何来源下载论文时，请遵守你所在机构、出版商和当地法律法规的授权范围。
 
 ---
 
 ## 快速开始
 
-### 安装
+### 1. 安装
 
 ```bash
 pip install scansci-pdf
 ```
 
-需要 WebVPN/CARSI/EZProxy 登录、付费墙浏览器下载或 Cloudflare 绕过时，安装可选浏览器和机构访问依赖：
+如果你需要学校登录、WebVPN/CARSI/EZProxy、Cloudflare 页面处理或可见浏览器下载，安装完整功能：
 
 ```bash
 pip install "scansci-pdf[cloakbrowser,instsci]"
 ```
 
-### 命令行使用
-
-如果不通过 MCP，也可以直接使用 `scansci-pdf` CLI：
-
-```bash
-# 直接下载 DOI/arXiv
-scansci-pdf get 10.1038/nature12373
-
-# 使用机构访问级联下载
-scansci-pdf fetch 10.1038/nature12373 --format markdown
-
-# 批量下载，每行一个 DOI 或 URL
-scansci-pdf batch dois.txt --output downloads
-
-# 启动浏览器 Web UI
-scansci-pdf web --port 8080
-
-# 浏览器登录并保存 cookie
-scansci-pdf login --login-type cookies --url https://www.sciencedirect.com/
-
-# 配置机构访问、查看浏览器状态、配置 Elsevier API
-scansci-pdf setup 北京大学
-scansci-pdf browser-status
-scansci-pdf elsevier-setup --api-key YOUR_KEY
-```
-
-### 检查环境
+### 2. 检查环境
 
 ```bash
 scansci-pdf check
 ```
 
-### MCP 配置
+### 3. 下载第一篇论文
 
-在任何支持 MCP 的 Agent 中添加以下配置即可使用：
+```bash
+scansci-pdf get 10.1038/nature12373
+```
+
+默认输出目录是：
+
+```text
+~/.scansci-pdf/papers
+```
+
+指定输出目录：
+
+```bash
+scansci-pdf get 10.1038/nature12373 --output downloads
+```
+
+### 4. 批量下载
+
+准备一个文本文件 `dois.txt`，每行一个 DOI 或 DOI URL：
+
+```text
+10.1038/nature12373
+10.1016/j.neunet.2026.108582
+https://doi.org/10.1126/science.aec6396
+```
+
+然后运行：
+
+```bash
+scansci-pdf batch dois.txt --output downloads
+```
+
+---
+
+## 推荐配置：Elsevier / ScienceDirect API
+
+如果你经常下载 Elsevier、ScienceDirect 或 Cell Press 的论文，建议首先配置 Elsevier API Key。配置后，ScanSci PDF 会优先使用官方 API：
+
+```text
+Article Retrieval API ?view=FULL
+  -> 获取全文 XML
+  -> 解析 PDF attachment-eid
+  -> Content Object API /content/object/eid/{eid}
+  -> 下载出版社正式 PDF
+```
+
+这条路径绕过 ScienceDirect 网页、Cloudflare 和验证码，但闭源全文仍取决于你的机构订阅和请求 IP 是否有授权。
+
+### 申请 API Key
+
+1. 打开 <https://dev.elsevier.com/>
+2. 注册或登录 Elsevier 账号。
+3. 进入 `My API Key` / API Key Settings。
+4. 创建 API Key；如果页面要求选择产品/API，选择 ScienceDirect / Article Retrieval 相关权限。
+5. 复制 API Key，不要把它写进公开文档、日志或仓库。
+
+### 保存到 ScanSci PDF
+
+```bash
+scansci-pdf elsevier-setup --api-key YOUR_KEY
+```
+
+如果你的图书馆明确提供 Elsevier institutional token，可以一并配置：
+
+```bash
+scansci-pdf elsevier-setup --api-key YOUR_KEY --inst-token YOUR_TOKEN
+```
+
+多数用户不需要 institutional token。校园网、学校 VPN、规则 VPN 或图书馆出口 IP 已经可能提供授权。若你配置了普通代理，请确认它没有覆盖 `api.elsevier.com` 的机构出口；ScanSci PDF 会对 Elsevier API 优先走 direct route，再回退到配置代理。配置后，可以下载一篇 Elsevier 论文确认是否已获得全文授权。
+
+更详细的路径说明和排查方法见 [Elsevier API 全文 PDF 稳定路径](docs/elsevier-api-fulltext-guide.md)。
+
+---
+
+## 需要机构权限的论文
+
+如果一篇论文不是开放获取，但你有学校或机构账号，可以使用以下方式。
+
+### 统一浏览器登录
+
+适合大多数出版商。工具会打开论文页面，你在浏览器里完成机构登录，之后 cookie 会保存复用。
+
+```bash
+scansci-pdf login --url https://www.sciencedirect.com/
+scansci-pdf get 10.1016/j.neunet.2026.108582
+```
+
+### WebVPN
+
+适合学校提供 WebVPN 的情况。
+
+```bash
+scansci-pdf schools 北京
+scansci-pdf setup 北京大学
+scansci-pdf fetch 10.1016/j.neunet.2026.108582 --format markdown
+```
+
+### CARSI / OpenAthens / Shibboleth
+
+适合出版商页面提供 `Access through your institution`、`Institutional Login`、`OpenAthens` 或 `Shibboleth` 的情况。
+
+```bash
+scansci-pdf federated-login sciencedirect
+scansci-pdf get 10.1016/j.neunet.2026.108582
+```
+
+登录、验证码、二次验证和机构密码都由用户在可见浏览器中完成，ScanSci PDF 不读取或保存你的密码。
+
+---
+
+## 常用命令
+
+| 你想做什么 | 命令 |
+|---|---|
+| 检查环境 | `scansci-pdf check` |
+| 下载单篇论文 | `scansci-pdf get DOI_OR_ARXIV` |
+| 下载并输出更详细结果 | `scansci-pdf fetch DOI --format markdown` |
+| 批量下载 DOI 列表 | `scansci-pdf batch dois.txt --output downloads` |
+| 搜索支持的学校 | `scansci-pdf schools 清华` |
+| 配置学校 WebVPN | `scansci-pdf setup 学校名称` |
+| 浏览器登录出版商 | `scansci-pdf login --url 出版商网址` |
+| 配置 Elsevier API | `scansci-pdf elsevier-setup --api-key YOUR_KEY` |
+| 查看或修改配置 | `scansci-pdf config-cmd` |
+| 启动 Web UI | `scansci-pdf web --port 8080` |
+| 检查浏览器运行时 | `scansci-pdf browser-doctor` |
+
+修改配置示例：
+
+```bash
+scansci-pdf config-cmd output_dir D:/papers
+scansci-pdf config-cmd network_proxy socks5://127.0.0.1:1080
+```
+
+---
+
+## 在 AI Agent / MCP 中使用
+
+ScanSci PDF 也可以作为 MCP 服务运行，让支持 MCP 的 Agent 直接调用论文搜索、下载和引文工具。
+
+### stdio 模式
+
+在 Claude Desktop、Cursor、Windsurf、Cline 等 MCP 客户端中添加：
 
 ```json
 {
@@ -86,267 +201,88 @@ scansci-pdf check
 }
 ```
 
-支持 MCP 的 Agent 和客户端：
+### HTTP 模式
 
-| 客户端 | 说明 |
-|--------|------|
-| Claude Desktop | Anthropic 官方桌面客户端 |
-| Claude Code | Anthropic 命令行 Agent |
-| Cursor | AI 代码编辑器 |
-| Windsurf | AI 代码编辑器 |
-| Cline | VS Code 插件 Agent |
-| Cherry Studio | 多模型桌面客户端 |
-| OpenClaw | MCP 客户端 |
-| 任何 MCP 兼容客户端 | MCP 是开放协议，任何实现均可接入 |
-
-<details>
-<summary>HTTP 模式（远程/Web 调用）</summary>
-
-适用于远程部署或不支持 stdio 的场景：
+适合远程部署或 Web 调用：
 
 ```bash
 scansci-pdf run --mode streamable_http --host 0.0.0.0 --port 8000
 ```
-</details>
 
----
+常用 MCP 工具：
 
-## 工作原理
-
-下载一篇论文时，ScanSci PDF 会同时启动多个数据源，按渠道类型和优先级分层竞速：
-
-```
-Tier 1 (4s)  ─ 开放/官方：出版商直链（OA/已授权访问）
-Tier 2 (5s)  ─ 开放/官方：OpenAlex / Unpaywall / DOAJ
-Tier 3 (8s)  ─ 开放/官方：EuropePMC / CORE / PMC / arXiv
-Tier 4 (25s) ─ 灰色渠道：LibGen / Sci-Hub / SciBban（可结合 Tor / CloakBrowser）
-Tier 5 (20s) ─ 机构渠道：WebVPN / CARSI / EZProxy / 浏览器 SSO
-```
-
-首个成功下载的源立即返回，其余自动取消。自适应评分系统会根据历史成功率和延迟动态调整源的优先级。
-
----
-
-## MCP 工具
-
-本节中的 `scansci_pdf_*` 是 MCP 工具名，用于在支持 MCP 的 Agent 或客户端内调用；终端命令请使用上一节的 `scansci-pdf ...` CLI。
-
-### 论文下载
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_smart_download` | 自动尝试所有源 + Tor 的直接下载 |
-| `scansci_pdf_download` | 下载单篇论文（完整参数控制） |
-| `scansci_pdf_batch_download` | 批量下载多篇论文 |
-| `scansci_pdf_resolve_and_download` | 解析列表 → 补全 DOI → 批量下载 |
-
-### 付费墙登录
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_login` | 统一登录：输入 DOI 自动识别出版商并打开浏览器 SSO |
-| `scansci_pdf_browser_login` | CloakBrowser 持久化浏览器登录 |
-| `scansci_pdf_browser_status` | 检查 CloakBrowser 状态 |
-| `scansci_pdf_browser_import_cookies` | 导入 Netscape cookie 到浏览器 |
-| `scansci_pdf_import_browser_cookies` | 打开浏览器捕获登录 cookie |
-
-### 搜索与解析
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_search` | 按关键词搜索论文（OpenAlex） |
-| `scansci_pdf_parse_list` | 解析 APA/BibTeX/DOI 列表文件 |
-
-### 引文管理
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_citation` | 获取论文引文（BibTeX/RIS/EndNote） |
-| `scansci_pdf_import_bib` | 导入 .bib 文件并下载全部论文 |
-| `scansci_pdf_paper_metadata` | 获取论文元数据 |
-| `scansci_pdf_zotero_push` | 将已下载论文推送到 Zotero |
-
-### 机构代理（WebVPN / CARSI / EZProxy）
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_instsci_set_school` | 设置 WebVPN 学校 |
-| `scansci_pdf_instsci_login` | WebVPN 浏览器 CAS 认证 |
-| `scansci_pdf_instsci_status` | WebVPN 登录状态 |
-| `scansci_pdf_instsci_schools` | 搜索支持的大学 |
-| `scansci_pdf_instsci_test` | 测试 WebVPN 连接性 |
-| `scansci_pdf_carsi_login` | CARSI 出版商机构登录 |
-| `scansci_pdf_carsi_status` | CARSI 状态与 cookie 检查 |
-| `scansci_pdf_ezproxy_login` | EZProxy 图书馆代理登录 |
-| `scansci_pdf_ezproxy_status` | EZProxy 状态检查 |
-
-### 系统管理
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_auto_setup` | 环境检测与自动配置 |
-| `scansci_pdf_setup_check` | 检测系统环境并给出安装建议 |
-| `scansci_pdf_health_check` | 检查所有数据源可用性与延迟 |
-| `scansci_pdf_network_diagnose` | 网络诊断 + 修复建议 |
-| `scansci_pdf_source_scores` | 各数据源历史成功率排名 |
-| `scansci_pdf_config_get` / `scansci_pdf_config_set` | 查看/修改配置 |
-| `scansci_pdf_cache_clear` | 清除下载缓存 |
-| `scansci_pdf_browser_doctor` | 检查可复用浏览器运行时 |
-| `scansci_pdf_elsevier_setup` | 配置或验证 Elsevier API Key |
-
-### Tor 管理
-
-| 工具 | 描述 |
-|------|------|
-| `scansci_pdf_tor_install` | 自动下载安装 Tor Expert Bundle |
-| `scansci_pdf_tor_start` | 启动内嵌 Tor SOCKS5 代理 |
-| `scansci_pdf_tor_stop` | 停止 Tor 代理 |
-
----
-
-## 下载流程
-
-下载采用两阶段模式，先跑开放/官方与灰色渠道，再在需要时进入机构渠道：
-
-1. **Phase 1 — 开放/官方 + 灰色渠道并行竞速**（15s 超时）：出版商直连、OA API（Unpaywall/OpenAlex/SemanticScholar/DOAJ/EuropePMC/CORE/PMC）、arXiv、Sci-Hub、LibGen、SciBban、浏览器源
-2. **Phase 2 — 机构渠道回退**（30s 超时）：仅当 Phase 1 全部失败时触发，通过 instsci 桥接、CARSI、WebVPN、EZProxy 或浏览器 SSO 获取
-
----
-
-## 付费墙：机构登录
-
-以下示例使用 MCP 工具调用语法；终端 CLI 对应命令见“命令行使用”。
-
-### 统一登录
-
-只需一行，自动识别出版商、打开浏览器、引导完成 SSO 登录，cookie 跨所有下载复用：
-
-```
-scansci_pdf_login(identifier="10.1126/science.aec6396")
-```
-
-`identifier` 可以是 DOI 或出版商名（`elsevier`, `wiley`, `nature`, `springer`, `ieee`, `science`, `tandfonline`, `acs`, `rsc`, `aip`, `aps`, `iop`, `oxford`, `acm`）。
-
-### WebVPN（高校代理）
-
-通过中国高校机构代理访问论文全文：
-
-```
-1. scansci_pdf_instsci_schools(query="北京")      → 搜索学校
-2. scansci_pdf_instsci_set_school(school="你的学校")
-3. scansci_pdf_instsci_login                     → 浏览器 CAS 认证
-4. scansci_pdf_instsci_test                      → 确认连接正常
-```
-
-支持 100+ 所高校。
-
-### CARSI（出版商联邦认证）
-
-直接通过出版商机构登录页面认证，无需 WebVPN 中转：
-
-```
-1. scansci_pdf_config_set(key="carsi_enabled", value="true")
-2. scansci_pdf_config_set(key="carsi_idp_name", value="你的学校名称")
-3. scansci_pdf_carsi_login(publisher="sciencedirect")
-```
-
-支持：sciencedirect, springer, wiley, ieee, tandfonline, nature
-
-### EZProxy（图书馆代理）
-
-通过学校图书馆 EZProxy 服务访问：
-
-```
-1. scansci_pdf_config_set(key="ezproxy_enabled", value="true")
-2. scansci_pdf_config_set(key="ezproxy_login_url", value="https://libproxy.你的学校.edu.cn/login?url={url}")
-3. scansci_pdf_ezproxy_login
-```
+| 工具 | 用途 |
+|---|---|
+| `scansci_pdf_download` | 下载单篇 DOI/arXiv |
+| `scansci_pdf_batch_download` | 批量下载 |
+| `scansci_pdf_search` | 搜索论文 |
+| `scansci_pdf_citation` | 获取 BibTeX/RIS/EndNote |
+| `scansci_pdf_login` | 打开浏览器完成机构登录 |
+| `scansci_pdf_elsevier_setup` | 引导配置 Elsevier API Key |
+| `scansci_pdf_network_diagnose` | 网络诊断 |
 
 ---
 
 ## 配置参考
 
-MCP 内通过 `scansci_pdf_config_set(key="...", value="...")` 修改；终端 CLI 可用 `scansci-pdf config-cmd key value` 修改。
-
 | 配置项 | 默认值 | 说明 |
-|--------|--------|------|
-| `scihub_enabled` | `true` | 启用 Sci-Hub |
-| `output_dir` | `~/.scansci-pdf/papers` | PDF 输出目录 |
-| `auto_rename` | `true` | 自动重命名 PDF |
-| `network_proxy` | （空） | HTTP/SOCKS 代理地址 |
+|---|---:|---|
+| `output_dir` | `~/.scansci-pdf/papers` | PDF 保存目录 |
+| `auto_rename` | `true` | 自动按作者/标题重命名 |
+| `scihub_enabled` | `true` | 启用 Sci-Hub/LibGen 类来源 |
+| `network_proxy` | 空 | HTTP/SOCKS 代理地址 |
 | `batch_workers` | `10` | 批量下载并发数 |
 | `instsci_enabled` | `false` | 启用 WebVPN |
-| `instsci_school` | （空） | WebVPN 学校名称 |
-| `carsi_enabled` | `false` | 启用 CARSI 联邦认证 |
-| `carsi_idp_name` | （空） | CARSI 机构名称 |
-| `browser_headless` | `false` | CloakBrowser 无头模式 |
-| `browser_humanize` | `true` | CloakBrowser 反检测人性化 |
-| `use_tor_for_scihub` | `true` | Sci-Hub 使用 Tor（明网失败后自动回退 .onion） |
+| `instsci_school` | 空 | WebVPN 学校名称 |
+| `carsi_enabled` | `false` | 启用 CARSI |
+| `carsi_idp_name` | 空 | CARSI 机构名称 |
+| `elsevier_api_key` | 空 | Elsevier / ScienceDirect API Key |
+| `elsevier_insttoken` | 空 | Elsevier institutional token，可选 |
+| `browser_headless` | `false` | 浏览器是否无头运行 |
+| `browser_humanize` | `true` | 浏览器人性化操作 |
+
+查看全部配置：
+
+```bash
+scansci-pdf config-cmd
+```
 
 ---
 
-## 高级功能（可选）
+## 可选高级功能
 
-以下功能为可选项，适用于特定网络环境或高级需求。
-
-### Elsevier API Key（ScienceDirect API）
-
-项目内置 Elsevier Retrieval API 通道。配置 API Key 后，ScienceDirect/Elsevier 论文会优先尝试 API 下载；是否能直接取得 PDF 仍取决于 API 权限、机构 token 或论文开放状态，失败时会回退到浏览器/机构访问流程。
-
-MCP 工具：
-
-```
-1. scansci_pdf_elsevier_setup
-2. scansci_pdf_config_set(key="elsevier_api_key", value="YOUR_KEY")
-3. scansci_pdf_elsevier_setup(test=true)
-```
-
-终端 CLI：
+### Web UI
 
 ```bash
-scansci-pdf elsevier-setup --api-key YOUR_KEY
+scansci-pdf web --port 8080
 ```
 
-### Docker 部署
+浏览器打开：
 
-适用于需要将 scansci-pdf 作为长期运行服务的场景，或不想在本机安装 Python 环境的用户。Docker 容器内置 MCP 服务器和 Tor 代理，数据通过 Docker 卷持久化。
+```text
+http://localhost:8080
+```
+
+### Docker
+
+适合长期运行服务或远程 MCP。
 
 ```bash
 docker compose up -d
 ```
 
-| 服务 | 说明 | 端口 |
-|------|------|------|
-| `scansci-pdf` | streamable HTTP MCP 服务器 | 8000 |
-| `tor` | Tor SOCKS5 代理 | 1080 |
+| 服务 | 端口 | 说明 |
+|---|---:|---|
+| `scansci-pdf` | `8000` | streamable HTTP MCP 服务 |
+| `tor` | `1080` | Tor SOCKS5 代理 |
 
-Docker 启动后会暴露 streamable HTTP MCP 服务。支持远程 MCP 的客户端可连接本机 `8000` 端口；如果客户端只支持 stdio，建议使用本地安装后的 `scansci-pdf run`。
+### Tor
 
-具体 URL 字段因客户端而异，通常指向 `http://localhost:8000/mcp`。
+如果你的网络无法访问某些来源，可以配置代理或使用 Tor。Docker 模式会提供 Tor 服务；本地模式可按诊断提示启用。
 
-### Tor 匿名代理
+### CloakBrowser
 
-Tor 用于在 Sci-Hub、LibGen 等网站被网络封锁的地区匿名访问。如果你的网络可以直连 Sci-Hub，则不需要 Tor。内嵌 Tor 会自动下载 Tor Expert Bundle（约 30MB），无需 Docker 或系统级安装。以下为 MCP 工具调用示例：
-
-```
-# 首次使用：自动下载安装 Tor
-scansci_pdf_tor_install
-
-# 启动 Tor SOCKS5 代理
-scansci_pdf_tor_start
-
-# 如果 Tor 本身也被封锁（连接超时），启用 obfs4 桥接绕过
-scansci_pdf_tor_start(use_bridges=true)
-
-# 下载时通过 Tor 访问
-scansci_pdf_download(identifier="10.1038/nature12373", use_tor=true)
-```
-
-二进制文件存储在 `~/.scansci-pdf/tor/`，不污染系统环境。
-
-### CloakBrowser（Cloudflare 绕过）
-
-当 Sci-Hub、LibGen 或出版商页面触发 Cloudflare/CAPTCHA/SSO 流程时，CloakBrowser 可提供可见浏览器会话和持久化 profile。它是可选依赖，不随基础安装强制安装：
+遇到 Cloudflare、CAPTCHA、SSO 或出版商浏览器下载时，安装可选浏览器依赖：
 
 ```bash
 pip install "scansci-pdf[cloakbrowser]"
@@ -357,29 +293,55 @@ scansci-pdf browser-doctor
 
 ## 故障排查
 
-**Sci-Hub 下载失败** — 在 MCP 中运行 `scansci_pdf_health_check(detailed=true)` 查看数据源状态。域名轮换会自动处理。如果遇到 Cloudflare 防护，安装可选 CloakBrowser 并运行 `scansci-pdf browser-status` 检查可用性。
+### 下载失败
 
-**Tor 连接失败** — 确认 Tor 运行在 `socks5h://127.0.0.1:1080`。如 Tor 也被封锁，使用 `scansci_pdf_tor_start(use_bridges=true)` 启用桥接。
+先运行：
 
-**WebVPN 登录失败** — 需要 CloakBrowser 与 WebVPN 加密依赖：`pip install "scansci-pdf[cloakbrowser,instsci]"`。登录在可见浏览器中完成，密码不经过本工具。
+```bash
+scansci-pdf check
+```
 
-**下载速度慢** — 运行 `scansci_pdf_health_check(detailed=true)` 检查数据源延迟。如 Sci-Hub 在你的网络被封锁，配置代理或禁用 Sci-Hub（`scansci_pdf_config_set(key="scihub_enabled", value="false")`）。
+如果你在 MCP 里使用：
 
-**网络问题** — 运行 `scansci_pdf_network_diagnose` 获取全面的连接诊断报告和针对性修复建议。
+```text
+scansci_pdf_network_diagnose
+```
+
+### Elsevier 返回 `NOT_ENTITLED`
+
+常见原因是当前请求没有走机构出口。请检查：
+
+- 是否已经连接校园网、学校 VPN 或规则 VPN
+- `api.elsevier.com` 是否被普通代理转发到非机构 IP
+- 学校是否订阅了目标期刊和年份
+
+### WebVPN 或机构登录失败
+
+- 确认安装了完整依赖：`pip install "scansci-pdf[cloakbrowser,instsci]"`
+- 在可见浏览器中完成登录、验证码或二次验证
+- 登录后重新运行下载命令
+
+### 下载速度慢
+
+- 配置 Elsevier API Key 可显著改善 ScienceDirect 论文下载速度
+- 批量任务可调整 `batch_workers`
+- 网络受限时配置 `network_proxy`
 
 ---
 
-## 架构说明
+## 更多资料
 
-本项目采用分层架构：
+- [Elsevier API 全文 PDF 稳定路径](docs/elsevier-api-fulltext-guide.md)
+- [Elsevier API 成功经验：迁移到 InstSci](docs/elsevier-api-success-experience-for-instsci.md)
+- [10 篇 Elsevier 闭源文章实测记录](elsevier_10_closed_articles.md)
 
-| 层级 | 内容 | 许可 |
-|------|------|------|
-| 公开层 | 所有 `.py` 源码、配置、文档 | Apache 2.0 |
-| 保护层 | `_core/*.pyx`（Cython 源码） | 专有，不公开 |
-| 分发层 | `_core/*.pyd`（编译二进制） | 随 PyPI 包分发 |
+---
 
-从 GitHub 克隆的用户使用纯 Python 回退实现（功能相同，性能略低）。从 PyPI 安装的用户自动获得编译版本。
+## 开发者说明
+
+本项目可作为 Python 包、CLI、Web UI 或 MCP 服务使用。核心下载流程会按来源健康度、响应速度和历史成功率动态排序，并在开放获取、出版商接口、机构访问和浏览器流程之间回退。
+
+从 GitHub 克隆的用户使用纯 Python 实现；从 PyPI 安装的用户可能获得预编译扩展以提升性能。
 
 ---
 
@@ -395,14 +357,11 @@ scansci-pdf browser-doctor
 
 本项目在开发过程中参考和借鉴了以下开源项目：
 
-- **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** — 早期反 bot 绕过架构设计（Docker 容器方案）
-- **[CloakBrowser](https://github.com/CloakHQ/CloakBrowser)** — Chromium stealth 浏览器，直接 Playwright API（当前方案）
-- **[cloakbrowser](https://github.com/CloakHQ/CloakBrowser)** — 原生 Chromium stealth 浏览器引擎（当前方案，本地 Python 库，无需 Docker）
-- **[ref-downloader](https://github.com/ltczding-gif/ref-downloader)** — Publisher 专用下载策略（Elsevier crasolve 检测、Wiley PDFDirect、AIP loading page 等）
-- **[paper-fetch-skill](https://github.com/Dictation354/paper-fetch-skill)** — 论文获取 Agent Skill 设计
-- **[paper-fetcher](https://github.com/fermionoid/paper-fetcher)** — 论文下载流程参考
-
-> **技术演进**：反 Cloudflare 方案经历了两代迭代 — FlareSolverr（Docker 容器）→ CloakBrowser（本地 Python 库），逐步从重型 Docker 依赖转向轻量本地集成。
+- **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** - 早期反 bot 绕过架构设计
+- **[CloakBrowser](https://github.com/CloakHQ/CloakBrowser)** - Chromium stealth 浏览器
+- **[ref-downloader](https://github.com/ltczding-gif/ref-downloader)** - Publisher 专用下载策略参考
+- **[paper-fetch-skill](https://github.com/Dictation354/paper-fetch-skill)** - 论文获取 Agent Skill 设计
+- **[paper-fetcher](https://github.com/fermionoid/paper-fetcher)** - 论文下载流程参考
 
 感谢以上项目作者的开源贡献。
 

--- a/docs/elsevier-api-fulltext-guide.md
+++ b/docs/elsevier-api-fulltext-guide.md
@@ -1,0 +1,113 @@
+# Elsevier API 全文 PDF 稳定路径
+
+更新时间：2026-06-20
+
+这份指南记录已验证的 Elsevier/ScienceDirect 全文 PDF 下载路径。它适用于有 Elsevier API Key，并且当前网络/IP 对目标文章有机构订阅权限的用户。
+
+如果要把这套经验迁移到 InstSci，见 `docs/elsevier-api-success-experience-for-instsci.md`。
+
+## 核心结论
+
+不要把 Article Retrieval API 的直接 PDF 响应当作唯一入口。对闭源文章，直接请求 PDF 可能只返回预览或被授权拦截。稳定路径是：
+
+1. 请求 Article Retrieval API 的全文 XML：
+   `GET https://api.elsevier.com/content/article/doi/{doi}?view=FULL`
+2. 从 XML 中解析正式 PDF 附件 ID，例如：
+   `1-s2.0-S0006320725007013-main.pdf`
+3. 请求 Content Object API：
+   `GET https://api.elsevier.com/content/object/eid/{attachment-eid}`
+4. 验证响应：
+   - `Content-Type` 为 PDF，或内容以 `%PDF-` 开头
+   - 页数大于 1
+   - 文件大小合理
+   - 若可得，`X-ELS-Status: OK`
+
+## 初次使用配置
+
+### 1. 申请 Elsevier API Key
+
+1. 打开 Elsevier Developer Portal：<https://dev.elsevier.com/>
+2. 注册或登录 Elsevier 账号。
+3. 进入 `My API Key` / API Key Settings。
+4. 创建新的 API Key；如果页面要求选择产品/API，选择 ScienceDirect / Article Retrieval 相关权限。
+5. 复制生成的 API Key，不要把 key 写进公开文档、日志或仓库。
+
+说明：
+- Elsevier 官方说明，API Key 可申请；非商业学术、公共机构、慈善等使用场景可免费使用多数 API。
+- 完整全文访问仍取决于机构订阅、API Key 权限，以及请求 IP/授权 token 的 entitlement。
+
+### 2. 配置 scansci-pdf
+
+MCP：
+
+```text
+scansci_pdf_config_set(key="elsevier_api_key", value="YOUR_KEY")
+scansci_pdf_elsevier_setup(test=true)
+```
+
+CLI：
+
+```bash
+scansci-pdf elsevier-setup --api-key YOUR_KEY --validate
+```
+
+可选：如果图书馆明确提供 Elsevier institutional token，再配置：
+
+```text
+scansci_pdf_config_set(key="elsevier_insttoken", value="YOUR_INST_TOKEN")
+```
+
+多数用户不需要 `elsevier_insttoken`；校园网、CARSI/VPN、图书馆出口 IP 已经可能构成授权上下文。
+
+### 3. 配置网络
+
+Elsevier 的全文 entitlement 与请求 IP 强相关。建议优先使用能让 `api.elsevier.com` 走机构出口的方式：
+
+- 校园网直连
+- 学校 VPN / 规则 VPN / TUN 模式
+- 图书馆认可的机构代理
+
+不要让 scansci-pdf 的 `network_proxy` 强制覆盖 Elsevier API 到非机构出口。当前实现对 Elsevier API 使用 direct-first 策略：先走系统路由，让规则 VPN 或校园网 IP 生效；direct 不通或无授权时，再回退到配置代理。
+
+## 程序实现规则
+
+Agent 或开发者维护 Elsevier 路径时遵守以下规则：
+
+1. 对 `10.1016/`、ScienceDirect、Elsevier、Cell Press 论文，配置了 `elsevier_api_key` 时优先尝试 Elsevier API。
+2. 第一个请求必须优先拿 XML：`Accept: application/xml` + `view=FULL`。
+3. 从 XML 中按优先级解析 PDF object EID：
+   - 明确的 `attachment-eid` / `object-eid`
+   - `web-pdf`、`attachment` 节点中的 MAIN/full-text PDF
+   - 兜底把文章 EID `1-s2.0-...` 推断为 `1-s2.0-...-main.pdf`
+4. 下载 PDF 时使用：
+   `https://api.elsevier.com/content/object/eid/{urlencoded-eid}`
+5. 拒绝一页预览 PDF；不要把预览当成功。
+6. direct route 优先，configured proxy 只作为 fallback。
+7. 失败时记录状态码、`X-ELS-Status` 和路由，但不要记录 API Key。
+
+## 常见返回与处理
+
+| 现象 | 常见原因 | 处理 |
+|---|---|---|
+| `view=FULL` 返回 400，提示 view invalid | 当前 IP/API Key 没有 FULL entitlement | 检查是否走机构出口；改用规则 VPN/TUN；确认机构订阅 |
+| `ENTITLED` 返回 `NOT_ENTITLED` | Elsevier 不认可当前请求 IP/授权上下文，或目标期刊不在订阅内 | 先确认 `api.elsevier.com` 没走普通代理；再换机构网络 |
+| object/eid 返回 401/403 | 附件存在，但当前授权无法下载对象 PDF | 同上，优先检查出口 IP 与机构订阅 |
+| 直接 PDF 返回 1 页 | 预览 PDF，不是正式全文 | 必须改走 XML -> object/eid |
+| OA 文章成功、闭源文章失败 | Key 有效，但无订阅 entitlement | 接入机构网络或机构 token |
+
+## 验证样例
+
+2026-06-20 规则 VPN 环境下，以下 10 篇闭源 Elsevier 文章通过 direct-first + XML/object-eid 全部成功：
+
+- `10.1016/j.jmst.2025.08.030`
+- `10.1016/j.jmst.2025.08.056`
+- `10.1016/j.seppur.2026.137141`
+- `10.1016/j.molstruc.2026.145682`
+- `10.1016/j.physio.2025.101870`
+- `10.1016/j.brainres.2026.150220`
+- `10.1016/j.neunet.2026.108539`
+- `10.1016/j.neunet.2026.108564`
+- `10.1016/j.neunet.2026.108617`
+- `10.1016/j.neunet.2026.108582`
+
+详细记录见仓库根目录 `elsevier_10_closed_articles.md`。

--- a/docs/elsevier-api-success-experience-for-instsci.md
+++ b/docs/elsevier-api-success-experience-for-instsci.md
@@ -1,0 +1,191 @@
+# Elsevier API 全文下载成功经验：可迁移到 InstSci
+
+更新时间：2026-06-20
+
+这份文档记录 scansci-pdf 在 Elsevier/ScienceDirect 闭源文章上跑通的经验，并整理成 InstSci 可以复用的配置与实现 checklist。核心前提是：用户拥有合法机构访问条件，例如校园网、学校 VPN、CARSI/图书馆出口或 Elsevier institutional token。
+
+## 一句话结论
+
+Elsevier 的网页 PDF 路线和 API 对象路线是两条路径。稳定成功的做法不是直接请求 Article Retrieval API 的 PDF，而是：
+
+```text
+Article Retrieval API ?view=FULL
+  -> 获取全文 XML
+  -> 解析 MAIN PDF 的 attachment-eid / object-eid
+  -> Content Object API /content/object/eid/{eid}
+  -> 下载出版社正式 PDF
+```
+
+这条路径不依赖 ScienceDirect 网页、`/pdfft`、Cloudflare 或浏览器验证码；它依赖 Elsevier API Key 与机构 entitlement。
+
+## 本次为什么成功
+
+之前失败不是因为 Elsevier object/eid 路线不可行，而是网络路由错了：
+
+- 项目配置了 `network_proxy`，Python 请求优先走普通代理出口。
+- Elsevier 对这个出口返回 `NOT_ENTITLED` / object 401。
+- 切换到规则 VPN 后，Python 的 direct route 能让 `api.elsevier.com` 走机构出口。
+- 修复策略改为 Elsevier API direct-first：先走系统路由/规则 VPN；direct 不通或无授权时，再 fallback 到配置代理。
+- 同一批 10 篇闭源 Elsevier 文章全部通过 XML -> object/eid 下载成功。
+
+## 必备配置
+
+### 1. Elsevier API Key
+
+用户自己申请：
+
+1. 打开 <https://dev.elsevier.com/>
+2. 注册或登录 Elsevier 账号。
+3. 进入 `My API Key` / API Key Settings。
+4. 创建 API Key；若页面要求选择产品/API，选择 ScienceDirect / Article Retrieval 相关权限。
+5. 保存到本地配置，不要写入公开日志、文档或仓库。
+
+建议 InstSci 配置项：
+
+```text
+elsevier_api_key = "..."
+elsevier_inst_token = ""   # 可选；仅图书馆明确提供时配置
+```
+
+多数用户不需要 `elsevier_inst_token`。校园网、规则 VPN、CARSI/VPN 或图书馆出口 IP 也可能提供 entitlement。
+
+### 2. 网络路由
+
+Elsevier 的闭源全文授权与请求 IP 强相关。InstSci 应该优先让 `api.elsevier.com` 走机构出口：
+
+- 校园网直连
+- 学校 VPN / 规则 VPN / TUN 模式
+- 图书馆认可的机构出口
+
+不要让普通 `network_proxy` 覆盖机构出口。推荐策略：
+
+```text
+route_options = [
+  direct,
+  configured_proxy,
+]
+```
+
+只有 direct 请求失败、超时或无授权时，再尝试 configured proxy。
+
+## InstSci 迁移 checklist
+
+### 实现顺序
+
+1. 在 InstSci 的 Elsevier API 源里先请求 XML：
+   - URL：`https://api.elsevier.com/content/article/doi/{doi}`
+   - Headers：`X-ELS-APIKey: ...`, `Accept: application/xml`
+   - Params：`view=FULL`
+2. 解析 XML 中的 PDF object EID：
+   - 优先 `attachment-eid` / `object-eid`
+   - 识别 `web-pdf`、`attachment`、`MAIN`、`full-text`
+   - 排除 `supplement`、`mmc`、`appendix`、`graphical` 等补充材料
+   - 若只有文章 EID `1-s2.0-...`，可兜底推断 `1-s2.0-...-main.pdf`
+3. 请求 Content Object API：
+   - URL：`https://api.elsevier.com/content/object/eid/{urlencoded-eid}`
+   - Headers：`X-ELS-APIKey: ...`, `Accept: application/pdf`
+4. 验证 PDF：
+   - 响应以 `%PDF-` 开头，或 `Content-Type` 包含 PDF
+   - 文件大小大于最小阈值
+   - 页数大于 1，拒绝一页预览
+   - 可选检查 DOI/标题文本
+5. direct-first，proxy fallback。
+6. 失败时记录 route、HTTP status、`X-ELS-Status`、content-type、bytes；不要记录 API Key。
+
+### 伪代码
+
+```python
+def fetch_elsevier_pdf(doi, config):
+    routes = [direct_route()]
+    if config.network_proxy:
+        routes.append(proxy_route(config.network_proxy))
+
+    for route in routes:
+        xml = get(
+            f"https://api.elsevier.com/content/article/doi/{quote(doi)}",
+            headers={
+                "X-ELS-APIKey": config.elsevier_api_key,
+                "Accept": "application/xml",
+            },
+            params={"view": "FULL"},
+            route=route,
+        )
+        if xml.status_code != 200:
+            continue
+
+        eids = extract_main_pdf_eids(xml.text)
+        for eid in eids:
+            pdf = get(
+                f"https://api.elsevier.com/content/object/eid/{quote(eid)}",
+                headers={
+                    "X-ELS-APIKey": config.elsevier_api_key,
+                    "Accept": "application/pdf",
+                },
+                route=route,
+            )
+            if is_valid_full_pdf(pdf.content):
+                return pdf.content
+
+    return None
+```
+
+## 验收标准
+
+最小验收：
+
+- 一个 OA Elsevier DOI 能拿到 `view=FULL` XML。
+- 一个有机构订阅的闭源 Elsevier DOI 能从 XML 解析到 `*-main.pdf` EID。
+- object/eid 返回正式 PDF，不是一页预览。
+- 配置了普通代理时，日志显示先尝试 direct route。
+- direct 成功时不再使用 configured proxy。
+- direct `NOT_ENTITLED` 时才尝试 configured proxy。
+
+推荐回归测试：
+
+- XML 中明确 `attachment-eid` 的样例。
+- XML 只有文章 EID 时推断 `-main.pdf`。
+- MAIN PDF 与 supplementary PDF 同时出现时优先 MAIN。
+- object/eid 返回 401/403 时不写入成功。
+- 直接 PDF 返回 1 页时拒绝。
+
+## 常见失败判断
+
+| 现象 | 含义 | 下一步 |
+|---|---|---|
+| `view=FULL` 返回 400 / view invalid | 当前 route 无 FULL entitlement | 检查是否走机构出口 |
+| ENTITLED 返回 `NOT_ENTITLED` | Elsevier 不认可当前 IP/授权上下文 | 关闭普通代理，使用校园网/规则 VPN |
+| object/eid 返回 401/403 | 对象存在，但当前授权不能下载 | 换机构出口或确认订阅范围 |
+| 直接 PDF 只有 1 页 | 预览，不是正式全文 | 拒绝并走 XML/object-eid |
+| OA 成功、闭源失败 | API Key 有效，但缺机构 entitlement | 需要机构网络或机构 token |
+
+## 与 InstSci browser evidence 的关系
+
+InstSci 的项目规则中，publisher PDF capability 或 closed-access 最终 verdict 可能要求 visible CloakBrowser 证据。Elsevier API 路线可以作为合法授权的快速获取通道和工程实现路径，但在报告能力矩阵或最终 publisher verdict 时，仍要遵守 InstSci 的 `AGENTS.md`：
+
+- HTTP/API 结果可标为 API route / HTTP preflight evidence。
+- 如果任务要求 browser-verified verdict，仍需 visible CloakBrowser 截图与下载证据。
+- 不要用 API 成功替代项目规则要求的浏览器证据，除非 InstSci 明确更新 evidence standard。
+
+## 可复制到 InstSci 的用户引导
+
+```text
+Elsevier/ScienceDirect 论文建议先配置 Elsevier API Key：
+1. 打开 https://dev.elsevier.com/
+2. 注册/登录 Elsevier 账号
+3. My API Key / API Key Settings -> 创建 API Key
+4. 若需要选择 API，选择 ScienceDirect / Article Retrieval
+5. 在 InstSci 配置 elsevier_api_key
+6. 使用校园网、学校 VPN 或规则 VPN，确保 api.elsevier.com 走机构出口
+
+下载时 InstSci 将优先：
+view=FULL XML -> 解析 MAIN PDF attachment-eid -> object/eid 下载正式 PDF。
+如果返回 NOT_ENTITLED，优先检查网络出口是否被普通代理覆盖。
+```
+
+## 实测记录
+
+2026-06-20，规则 VPN 环境下，scansci-pdf 使用 direct-first + XML/object-eid 路线，10 篇闭源 Elsevier 文章全部成功下载。记录见：
+
+- scansci-pdf：`elsevier_10_closed_articles.md`
+- PDF 输出目录：`C:\Users\Liang\.scansci-pdf\papers\elsevier_api_rule_vpn_direct_first_20260620_224223`
+

--- a/elsevier_10_closed_articles.md
+++ b/elsevier_10_closed_articles.md
@@ -1,0 +1,28 @@
+# Elsevier 10 篇闭源文章测试清单
+
+生成时间：2026-06-20 22:42
+
+测试逻辑：`Article Retrieval API ?view=FULL` -> 从 XML 解析 PDF `attachment-eid` -> `Content Object API /content/object/eid/{eid}` 下载出版社正式 PDF。
+
+本次修复后的路由策略：Elsevier API 优先走 `direct`，让规则 VPN / 校园网 IP 生效；如果 direct 不通或无授权，再回退到项目配置的 `network_proxy`。
+
+稳定指南：`docs/elsevier-api-fulltext-guide.md`
+
+测试报告：`C:\Users\Liang\.scansci-pdf\papers\elsevier_api_rule_vpn_direct_first_20260620_224223\summary.json`
+
+PDF 目录：`C:\Users\Liang\.scansci-pdf\papers\elsevier_api_rule_vpn_direct_first_20260620_224223`
+
+| # | DOI | PDF object EID | 结果 | 页数 | 大小 | 本地 PDF |
+|---:|---|---|---|---:|---:|---|
+| 1 | `10.1016/j.jmst.2025.08.030` | `1-s2.0-S1005030225008977-main.pdf` | 成功 | 16 | 9,916,588 bytes | `01_10.1016_j.jmst.2025.08.030.pdf` |
+| 2 | `10.1016/j.jmst.2025.08.056` | `1-s2.0-S1005030225009569-main.pdf` | 成功 | 10 | 3,712,591 bytes | `02_10.1016_j.jmst.2025.08.056.pdf` |
+| 3 | `10.1016/j.seppur.2026.137141` | `1-s2.0-S1383586626004077-main.pdf` | 成功 | 13 | 4,627,162 bytes | `03_10.1016_j.seppur.2026.137141.pdf` |
+| 4 | `10.1016/j.molstruc.2026.145682` | `1-s2.0-S0022286026004485-main.pdf` | 成功 | 8 | 4,666,334 bytes | `04_10.1016_j.molstruc.2026.145682.pdf` |
+| 5 | `10.1016/j.physio.2025.101870` | `1-s2.0-S0031940625004080-main.pdf` | 成功 | 13 | 6,483,372 bytes | `05_10.1016_j.physio.2025.101870.pdf` |
+| 6 | `10.1016/j.brainres.2026.150220` | `1-s2.0-S0006899326000788-main.pdf` | 成功 | 11 | 4,884,187 bytes | `06_10.1016_j.brainres.2026.150220.pdf` |
+| 7 | `10.1016/j.neunet.2026.108539` | `1-s2.0-S089360802600002X-main.pdf` | 成功 | 17 | 3,129,251 bytes | `07_10.1016_j.neunet.2026.108539.pdf` |
+| 8 | `10.1016/j.neunet.2026.108564` | `1-s2.0-S0893608026000274-main.pdf` | 成功 | 27 | 16,050,377 bytes | `08_10.1016_j.neunet.2026.108564.pdf` |
+| 9 | `10.1016/j.neunet.2026.108617` | `1-s2.0-S0893608026000791-main.pdf` | 成功 | 15 | 4,211,724 bytes | `09_10.1016_j.neunet.2026.108617.pdf` |
+| 10 | `10.1016/j.neunet.2026.108582` | `1-s2.0-S0893608026000456-main.pdf` | 成功 | 17 | 4,048,480 bytes | `10_10.1016_j.neunet.2026.108582.pdf` |
+
+结论：10 篇全部跑通。失败根因不是 Elsevier object/eid 流程不可行，而是之前项目强制走了配置代理出口；该出口被 Elsevier 判定为 `NOT_ENTITLED`。规则 VPN 后，Python direct 路径能被 Elsevier 识别为有机构授权。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scansci-pdf"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP server for academic paper downloading with Sci-Hub, OA sources, multi-university WebVPN, and Tor support"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -6,8 +6,9 @@ description: >
   import .bib files, or batch-download papers. This skill orchestrates the scansci-pdf MCP server
   which has 13+ download sources, 100+ university WebVPNs, and parallel download.
   TRIGGER when: user mentions downloading papers, DOI, arXiv ID, Sci-Hub, paper search,
-  literature review, citation export, WebVPN, institutional access, "帮我下载论文", "搜索文献",
-  "批量下载", "论文下载", "文献检索", or provides a list of DOIs/arXiv IDs.
+  literature review, citation export, WebVPN, institutional access, Elsevier API, ScienceDirect,
+  "帮我下载论文", "搜索文献", "批量下载", "论文下载", "文献检索",
+  "配置 Elsevier API", or provides a list of DOIs/arXiv IDs.
   SKIP: user is only discussing papers conceptually without intent to download/search/cite,
   or user asks about non-academic PDFs (invoices, reports, etc.).
 ---
@@ -164,8 +165,8 @@ scansci_pdf_ezproxy_login
 |--------|--------|------|
 | `scihub_enabled` | `true` | 启用 Sci-Hub/LibGen |
 | `openalex_api_key` | `""` | OpenAlex Content API key（免费，每天 100 次） |
-| `elsevier_api_key` | `""` | Elsevier API key（ScienceDirect Article Retrieval API） |
-| `elsevier_insttoken` | `""` | Elsevier 机构令牌（需学校图书馆申请） |
+| `elsevier_api_key` | `""` | Elsevier API key（ScienceDirect Article Retrieval API，首次使用推荐配置） |
+| `elsevier_insttoken` | `""` | Elsevier 机构令牌（可选；仅在图书馆明确提供时配置） |
 | `network_proxy` | `""` | 全局代理（如 `socks5://127.0.0.1:1080`） |
 | `batch_workers` | `10` | 批量下载并发数 |
 | `auto_rename` | `true` | 自动重命名为作者+标题 |
@@ -260,35 +261,44 @@ scansci_pdf_ezproxy_login
 
 ### 流程 6：Elsevier API Key 配置（ScienceDirect 快速通道）
 
-当 Elsevier/ScienceDirect 论文（DOI 以 `10.1016/` 开头）下载失败或需要更快下载时触发：
+首次使用 scansci-pdf、遇到 Elsevier/ScienceDirect/Cell Press 论文（DOI 常以 `10.1016/` 开头）、用户有校园网/VPN/机构网络、或下载失败提示 `elsevier_setup` 时，优先引导配置 Elsevier API Key。不要把它当作最后兜底；它是 ScienceDirect 的最快稳定通道。
 
 ```
 1. scansci_pdf_elsevier_setup
-   → 自动打开浏览器到 Elseveloper Developer Portal
-   → 返回详细注册步骤（中文指引）
+   → 自动打开 Elsevier Developer Portal
+   → 返回注册与配置步骤
 
 2. 用户在浏览器中：
-   → 注册/登录 → 点击 "My API Key" → 创建应用
-   → 选择 "ScienceDirect Article Retrieval" API → 复制 API Key
+   → 注册/登录 Elsevier 账号
+   → 进入 "My API Key" / API Key Settings
+   → 创建 API Key；如果页面要求选择产品/API，选择 ScienceDirect / Article Retrieval 相关权限
+   → 复制 API Key
 
 3. scansci_pdf_config_set(key="elsevier_api_key", value="用户的APIKey")
 
 4. scansci_pdf_elsevier_setup(test=true)
-   → 验证 key 有效性 → 返回成功/失败状态
+   → 验证 key 基本有效性
 
-5. 后续所有 Elsevier 论文自动走 API 直接下载（1-2秒）
+5. 确认网络：
+   → 校园网、学校 VPN、规则 VPN 或机构出口已生效
+   → 如果配置了 network_proxy，确认它不是普通非机构代理；Elsevier API 应优先走 direct route
+
+6. 后续 Elsevier/ScienceDirect/Cell Press 论文自动优先走 API
 ```
 
 **触发时机：**
+- 初次使用且用户会下载 Elsevier/ScienceDirect 论文时
 - 下载返回结果中 `hint` 包含 "elsevier_setup" 时
 - 用户提到 ScienceDirect/Elsevier 论文下载慢或失败时
 - 用户主动要求配置 API key 时
 
 **关键点：**
-- 申请完全免费，无需机构邮箱
-- 配置一次，所有 Elsevier/ScienceDirect/Cell Press 论文受益
-- API 下载比浏览器快 10-30 倍，且不受 Cloudflare 拦截影响
-- 不配置也能用（走浏览器登录回退），但配置后体验大幅提升
+- API key 可在 Elsevier Developer Portal 申请；不要把 key 写进日志、文档或仓库
+- 完整闭源全文取决于机构订阅和请求 IP entitlement；API key 本身不等于所有文章全文授权
+- 稳定路径不是直接请求 PDF，而是：`Article Retrieval API ?view=FULL` → XML 中解析 PDF `attachment-eid` → `Content Object API /content/object/eid/{eid}`
+- 对有校园网/规则 VPN 的用户，Elsevier API 应 direct-first，让 `api.elsevier.com` 走机构出口；普通代理可能导致 `NOT_ENTITLED`
+- 直接 PDF 响应若只有 1 页是预览，必须拒绝并继续 XML/object-eid 路径
+- 详细实现和排查见仓库 `docs/elsevier-api-fulltext-guide.md`
 
 ### 流程 4：故障排查
 
@@ -342,8 +352,8 @@ scansci_pdf_ezproxy_login
 ### 快速安装
 
 ```
-# 0.（推荐）配置 Elsevier API Key，ScienceDirect 论文直接下载
-scansci_pdf_elsevier_setup → 打开浏览器注册 → 复制 key → scansci_pdf_config_set
+# 0.（推荐）配置 Elsevier API Key，ScienceDirect 论文走 FULL XML → object/eid 快速通道
+scansci_pdf_elsevier_setup → 打开浏览器注册 → 复制 key → scansci_pdf_config_set → scansci_pdf_elsevier_setup(test=true)
 
 # 1. 自动下载安装 Tor（首次使用）
 scansci_pdf_tor_install

--- a/src/scansci_pdf/__init__.py
+++ b/src/scansci_pdf/__init__.py
@@ -45,7 +45,7 @@ def _fix_ssl_cert_file() -> None:
 
 _fix_ssl_cert_file()
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 __all__ = [
     "__version__",

--- a/src/scansci_pdf/cli.py
+++ b/src/scansci_pdf/cli.py
@@ -1334,7 +1334,7 @@ def elsevier_setup(
     inst_token: str = typer.Option("", "--inst-token", help="Elsevier institutional token."),
     validate: bool = typer.Option(False, "--validate", help="Validate an existing API key."),
 ):
-    """Set up Elsevier API key for direct PDF download.
+    """Set up Elsevier API key for ScienceDirect full-text retrieval.
 
     Get a free key at: https://dev.elsevier.com/
     """
@@ -1356,11 +1356,13 @@ def elsevier_setup(
         console.print()
         console.print("To get a free API key:")
         console.print("  1. Go to [cyan]https://dev.elsevier.com/[/cyan]")
-        console.print("  2. Register and create an API key")
-        console.print("  3. Run: [cyan]instsci elsevier-setup --api-key YOUR_KEY[/cyan]")
+        console.print("  2. Register/sign in, then open My API Key / API Key Settings")
+        console.print("  3. Create an API key; choose ScienceDirect / Article Retrieval if asked")
+        console.print("  4. Run: [cyan]scansci-pdf elsevier-setup --api-key YOUR_KEY --validate[/cyan]")
         console.print()
-        console.print("With an institutional token, you get full-text PDF access:")
-        console.print("  [cyan]instsci elsevier-setup --api-key KEY --inst-token TOKEN[/cyan]")
+        console.print("Closed full text still depends on institutional subscription/IP entitlement.")
+        console.print("If your library provides an Elsevier institutional token:")
+        console.print("  [cyan]scansci-pdf elsevier-setup --api-key KEY --inst-token TOKEN[/cyan]")
         raise typer.Exit(0)
 
     if validate:
@@ -1386,24 +1388,27 @@ def elsevier_setup(
         except Exception as e:
             console.print(f"[red]Validation failed: {e}[/red]")
 
-        # Check PDF access
+        # Check Article Retrieval XML access. Closed object-PDF entitlement is tested by normal download.
         console.print()
-        console.print("Testing PDF access...")
+        console.print("Testing Article Retrieval XML access...")
         try:
             resp = requests.get(
-                "https://api.elsevier.com/content/article/doi/10.1016/j.watres.2024.121507",
-                headers={"X-ELS-APIKey": key, "Accept": "application/pdf"},
+                "https://api.elsevier.com/content/article/doi/10.1016/j.nicl.2021.102600",
+                headers={"X-ELS-APIKey": key, "Accept": "application/xml"},
+                params={"view": "FULL"},
                 timeout=30,
             )
             ct = resp.headers.get("content-type", "")
-            if resp.status_code == 200 and "pdf" in ct:
-                console.print(f"[green]PDF access: YES ({len(resp.content)} bytes)[/green]")
-            elif resp.status_code == 200:
-                console.print(f"[yellow]PDF access: NO (got {ct[:40]}, need institutional token)[/yellow]")
+            if resp.status_code == 200 and "xml" in ct:
+                console.print(f"[green]Article Retrieval XML: YES ({len(resp.content)} bytes)[/green]")
+                console.print(
+                    "  Closed Elsevier PDFs use: view=FULL XML -> attachment-eid -> "
+                    "Content Object API /object/eid/{eid}."
+                )
             else:
-                console.print(f"[yellow]PDF access: HTTP {resp.status_code}[/yellow]")
+                console.print(f"[yellow]Article Retrieval XML: HTTP {resp.status_code} ({ct[:40]})[/yellow]")
         except Exception as e:
-            console.print(f"[red]PDF test failed: {e}[/red]")
+            console.print(f"[red]Article Retrieval XML test failed: {e}[/red]")
 
     console.print()
     console.print(f"  API Key:        {key[:8]}...{key[-4:]}" if len(key) > 12 else f"  API Key:        {key}")

--- a/src/scansci_pdf/main.py
+++ b/src/scansci_pdf/main.py
@@ -405,7 +405,7 @@ def elsevier_setup(
     api_key: str = typer.Option("", help="Elsevier API key"),
     inst_token: str = typer.Option("", help="Elsevier institutional token"),
 ) -> None:
-    """Configure Elsevier API access for direct full-text retrieval."""
+    """Configure Elsevier API access for ScienceDirect full-text retrieval."""
     from .config import load_config, save_config
 
     config = load_config()
@@ -425,7 +425,15 @@ def elsevier_setup(
         has_token = bool(config.get("elsevier_insttoken"))
         print(f"  Elsevier API key:   {'set' if has_key else '(not set)'}")
         print(f"  Elsevier inst token: {'set' if has_token else '(not set)'}")
-        print(f"\n  Usage: scansci-pdf elsevier-setup --api-key YOUR_KEY --inst-token YOUR_TOKEN")
+        print("\n  Get a free API key:")
+        print("    1. Visit https://dev.elsevier.com/")
+        print("    2. Sign in, open My API Key / API Key Settings, create a key")
+        print("    3. If asked, choose ScienceDirect / Article Retrieval permissions")
+        print("\n  Usage:")
+        print("    scansci-pdf elsevier-setup --api-key YOUR_KEY")
+        print("    scansci-pdf elsevier-setup --api-key YOUR_KEY --inst-token YOUR_TOKEN")
+        print("\n  Closed full text depends on institutional subscription and request IP.")
+        print("  Campus/VPN users should let api.elsevier.com use the institution route.")
 
 
 @app.command("session-doctor")

--- a/src/scansci_pdf/publisher_strategies.py
+++ b/src/scansci_pdf/publisher_strategies.py
@@ -1745,6 +1745,327 @@ def _persist_api_cookies(session: Any, config: dict[str, Any]) -> int:
     return meaningful
 
 
+def _elsevier_header(headers: Any, name: str) -> str:
+    """Return a response header value using case-insensitive matching."""
+    if not headers:
+        return ""
+    value = headers.get(name)
+    if value is not None:
+        return str(value)
+    needle = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == needle:
+            return str(value)
+    return ""
+
+
+def _elsevier_response_is_pdf(resp: Any) -> bool:
+    content_type = _elsevier_header(getattr(resp, "headers", {}), "content-type").lower()
+    content = getattr(resp, "content", b"") or b""
+    return "pdf" in content_type or content[:5] == b"%PDF-"
+
+
+def _elsevier_response_is_xml(resp: Any) -> bool:
+    content_type = _elsevier_header(getattr(resp, "headers", {}), "content-type").lower()
+    content = (getattr(resp, "content", b"") or b"").lstrip()
+    return (
+        "xml" in content_type
+        or content.startswith(b"<?xml")
+        or content.startswith(b"<full-text-retrieval-response")
+    )
+
+
+def _elsevier_response_text(resp: Any) -> str:
+    text = getattr(resp, "text", None)
+    if isinstance(text, str):
+        return text
+    content = getattr(resp, "content", b"") or b""
+    return content.decode("utf-8", errors="replace")
+
+
+def _elsevier_xml_local_name(name: str) -> str:
+    return name.rsplit("}", 1)[-1].split(":", 1)[-1].lower()
+
+
+def _elsevier_element_text(el: Any) -> str:
+    return " ".join(" ".join(el.itertext()).split())
+
+
+def _elsevier_looks_like_pdf_eid(value: str) -> bool:
+    lowered = value.strip().lower()
+    return bool(lowered) and (lowered.endswith(".pdf") or ".pdf" in lowered)
+
+
+def _elsevier_article_eid_to_main_pdf(value: str) -> str:
+    candidate = value.strip()
+    if candidate.lower().startswith("eid:"):
+        candidate = candidate.split(":", 1)[1].strip()
+    if not candidate.startswith("1-s2.0-"):
+        return ""
+    if candidate.lower().endswith(".pdf"):
+        return candidate
+    return f"{candidate}-main.pdf"
+
+
+def _elsevier_attachment_container(el: Any, parent_map: dict[Any, Any]) -> Any:
+    node = parent_map.get(el, el)
+    while node is not None:
+        local = _elsevier_xml_local_name(str(node.tag))
+        if "attachment" in local or "object" in local:
+            return node
+        node = parent_map.get(node)
+    return parent_map.get(el, el)
+
+
+def _elsevier_attachment_metadata(el: Any) -> str:
+    parts: list[str] = []
+    for node in el.iter():
+        local = _elsevier_xml_local_name(str(node.tag))
+        text = _elsevier_element_text(node)
+        if text:
+            parts.append(f"{local}:{text}")
+        for attr_name, attr_value in node.attrib.items():
+            attr_local = _elsevier_xml_local_name(str(attr_name))
+            if attr_value:
+                parts.append(f"{attr_local}:{attr_value}")
+    return " ".join(parts).lower()
+
+
+def _elsevier_attachment_score(eid: str, metadata: str) -> int:
+    haystack = f"{eid} {metadata}".lower()
+    score = 0
+    if eid.lower().endswith(".pdf"):
+        score += 20
+    if "pdf" in haystack:
+        score += 10
+    if "main" in haystack or "full-text" in haystack or "fulltext" in haystack:
+        score += 100
+    if "page-count" in haystack or "pages" in haystack:
+        score += 5
+    if "attachment-size" in haystack or "filesize" in haystack or "file-size" in haystack:
+        score += 5
+    if any(marker in haystack for marker in (
+        "supplement", "supplementary", "mmc", "appendix", "graphical", "thumbnail",
+    )):
+        score -= 100
+    return score
+
+
+def _extract_elsevier_pdf_attachment_eids(xml_text: str) -> list[str]:
+    """Extract candidate publisher PDF object EIDs from Elsevier full-text XML."""
+    import xml.etree.ElementTree as ET
+
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        log.info(f"   [ElsevierAPI] XML parse failed: {exc}")
+        return []
+
+    parent_map = {child: parent for parent in root.iter() for child in parent}
+    candidates: list[tuple[int, int, str]] = []
+    seen: set[str] = set()
+
+    for el in root.iter():
+        found: list[str] = []
+        local = _elsevier_xml_local_name(str(el.tag))
+        if local in {"attachment-eid", "object-eid"}:
+            text = _elsevier_element_text(el)
+            if _elsevier_looks_like_pdf_eid(text):
+                found.append(text)
+        elif local in {"eid", "identifier"}:
+            text = _elsevier_element_text(el)
+            main_pdf = _elsevier_article_eid_to_main_pdf(text)
+            if main_pdf:
+                found.append(main_pdf)
+
+        for attr_name, attr_value in el.attrib.items():
+            attr_local = _elsevier_xml_local_name(str(attr_name))
+            if attr_local in {"attachment-eid", "object-eid", "eid"}:
+                value = str(attr_value).strip()
+                if _elsevier_looks_like_pdf_eid(value):
+                    found.append(value)
+                else:
+                    main_pdf = _elsevier_article_eid_to_main_pdf(value)
+                    if main_pdf:
+                        found.append(main_pdf)
+
+        for eid in found:
+            if eid in seen:
+                continue
+            seen.add(eid)
+            container = _elsevier_attachment_container(el, parent_map)
+            metadata = _elsevier_attachment_metadata(container)
+            candidates.append((
+                _elsevier_attachment_score(eid, metadata),
+                len(candidates),
+                eid,
+            ))
+
+    candidates.sort(key=lambda item: (-item[0], item[1]))
+    return [eid for _, _, eid in candidates]
+
+
+def _elsevier_pdf_page_count(content: bytes) -> int | None:
+    """Best-effort page count for detecting Elsevier one-page preview PDFs."""
+    try:
+        import fitz  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    try:
+        with fitz.open(stream=content, filetype="pdf") as doc:
+            return int(doc.page_count)
+    except Exception:
+        return None
+
+
+def _save_elsevier_pdf_content(
+    doi: str,
+    output_path: Path,
+    content: bytes,
+    config: dict[str, Any],
+    source: str,
+    *,
+    reject_single_page: bool = False,
+) -> dict[str, Any] | None:
+    from .pdf_utils import is_pdf_file, success
+
+    if len(content) < config.get("min_pdf_size_bytes", 10000):
+        log.info(f"   [ElsevierAPI] response too small ({len(content)} bytes)")
+        return None
+    if reject_single_page:
+        page_count = _elsevier_pdf_page_count(content)
+        if page_count == 1:
+            output_path.unlink(missing_ok=True)
+            log.info(f"   [ElsevierAPI] direct PDF is a 1-page preview for {doi}")
+            return None
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(content)
+    if is_pdf_file(output_path):
+        log.info(f"   [ElsevierAPI] downloaded {len(content)} bytes for {doi}")
+        return success(doi, output_path, source)
+
+    output_path.unlink(missing_ok=True)
+    return None
+
+
+def _try_elsevier_object_pdf_from_xml(
+    doi: str,
+    output_path: Path,
+    config: dict[str, Any],
+    session: Any,
+    article_url: str,
+    headers: dict[str, str],
+    first_resp: Any,
+    *,
+    full_xml_already_tried: bool = False,
+) -> dict[str, Any] | None:
+    import urllib.parse
+
+    xml_resp = None
+    if (
+        first_resp is not None
+        and getattr(first_resp, "status_code", 0) == 200
+        and _elsevier_response_is_xml(first_resp)
+    ):
+        xml_resp = first_resp
+
+    if xml_resp is None:
+        xml_headers = dict(headers)
+        xml_headers["Accept"] = "application/xml"
+        param_options = [None] if full_xml_already_tried else [{"view": "FULL"}, None]
+        for params in param_options:
+            try:
+                request_kwargs: dict[str, Any] = {
+                    "headers": xml_headers,
+                    "timeout": 30,
+                    "allow_redirects": True,
+                }
+                if params:
+                    request_kwargs["params"] = params
+                candidate = session.get(article_url, **request_kwargs)
+            except Exception as exc:
+                log.info(f"   [ElsevierAPI] XML request failed: {exc}")
+                continue
+
+            if getattr(candidate, "status_code", 0) != 200:
+                view_name = "FULL XML" if params else "XML"
+                log.info(
+                    f"   [ElsevierAPI] {view_name} HTTP "
+                    f"{getattr(candidate, 'status_code', 0)} for {doi}"
+                )
+                continue
+            if not _elsevier_response_is_xml(candidate):
+                content_type = _elsevier_header(
+                    getattr(candidate, "headers", {}),
+                    "content-type",
+                )
+                view_name = "FULL XML" if params else "XML"
+                log.info(
+                    f"   [ElsevierAPI] {view_name} request returned non-XML "
+                    f"({content_type[:50]})"
+                )
+                continue
+
+            xml_resp = candidate
+            break
+
+        if xml_resp is None:
+            return None
+
+    eids = _extract_elsevier_pdf_attachment_eids(_elsevier_response_text(xml_resp))
+    if not eids:
+        log.info(f"   [ElsevierAPI] XML has no PDF attachment EID for {doi}")
+        return None
+
+    object_headers = dict(headers)
+    object_headers["Accept"] = "application/pdf"
+    for eid in eids:
+        object_url = (
+            "https://api.elsevier.com/content/object/eid/"
+            f"{urllib.parse.quote(eid, safe='')}"
+        )
+        try:
+            object_resp = session.get(
+                object_url,
+                headers=object_headers,
+                timeout=30,
+                allow_redirects=True,
+            )
+        except Exception as exc:
+            log.info(f"   [ElsevierAPI] object {eid} request failed: {exc}")
+            continue
+
+        if getattr(object_resp, "status_code", 0) != 200:
+            log.info(
+                f"   [ElsevierAPI] object {eid} HTTP "
+                f"{getattr(object_resp, 'status_code', 0)}"
+            )
+            continue
+        if not _elsevier_response_is_pdf(object_resp):
+            content_type = _elsevier_header(
+                getattr(object_resp, "headers", {}),
+                "content-type",
+            )
+            log.info(f"   [ElsevierAPI] object {eid} returned non-PDF ({content_type[:50]})")
+            continue
+
+        result = _save_elsevier_pdf_content(
+            doi,
+            output_path,
+            getattr(object_resp, "content", b"") or b"",
+            config,
+            "ElsevierAPI",
+            reject_single_page=True,
+        )
+        if result:
+            log.info(f"   [ElsevierAPI] downloaded object PDF via attachment EID {eid}")
+            return result
+
+    return None
+
+
 def try_elsevier_api(
     doi: str, output_path: Path, config: dict[str, Any],
 ) -> dict[str, Any] | None:
@@ -1768,13 +2089,11 @@ def try_elsevier_api(
                  f"Run scansci_pdf_elsevier_setup to configure (free).")
         return None
 
-    from .pdf_utils import is_pdf_file, success
-    from .network import USER_AGENT
+    from .network import USER_AGENT, proxy_dict, select_proxy_for_url
 
     url = f"https://api.elsevier.com/content/article/doi/{doi}"
 
     headers: dict[str, str] = {
-        "Accept": "application/pdf",
         "User-Agent": USER_AGENT,
         "X-ELS-APIKey": api_key,
     }
@@ -1782,53 +2101,89 @@ def try_elsevier_api(
     if insttoken:
         headers["X-ELS-InstToken"] = insttoken
 
+    proxy = select_proxy_for_url(url, config)
+    configured_proxies = proxy_dict(proxy)
+    route_options: list[tuple[str, dict[str, str]]] = [("direct", {})]
+    if configured_proxies:
+        route_options.append(("configured proxy", configured_proxies))
+
     import requests
-    try:
-        session = requests.Session()
-        session.trust_env = False
-        resp = session.get(url, headers=headers, timeout=30, allow_redirects=True)
-    except Exception as e:
-        log.info(f"   [ElsevierAPI] request failed: {e}")
-        return None
 
-    if resp.status_code != 200:
-        if resp.status_code in (403, 429):
-            log.info(f"   [ElsevierAPI] HTTP {resp.status_code} — "
-                     f"API 配额可能已耗尽，自动切换浏览器策略。")
-        else:
-            log.info(f"   [ElsevierAPI] HTTP {resp.status_code} for {doi}")
-        return None
+    for route_name, proxies in route_options:
+        try:
+            session = requests.Session()
+            session.trust_env = False
+            if proxies:
+                session.proxies = proxies
 
-    content_type = resp.headers.get("Content-Type", "")
-    is_pdf = "pdf" in content_type or resp.content[:5] == b"%PDF-"
+            log.info(f"   [ElsevierAPI] trying {route_name} route")
+            xml_headers = dict(headers)
+            xml_headers["Accept"] = "application/xml"
+            resp = session.get(
+                url,
+                headers=xml_headers,
+                params={"view": "FULL"},
+                timeout=30,
+                allow_redirects=True,
+            )
+        except Exception as e:
+            log.info(f"   [ElsevierAPI] {route_name} FULL XML request failed: {e}")
+            continue
 
-    if is_pdf:
-        # API returned PDF directly — save it
-        if len(resp.content) < config.get("min_pdf_size_bytes", 10000):
-            log.info(f"   [ElsevierAPI] response too small ({len(resp.content)} bytes)")
-            return None
+        if resp is not None and resp.status_code != 200:
+            if resp.status_code in (403, 429):
+                log.info(
+                    f"   [ElsevierAPI] {route_name} HTTP {resp.status_code}; "
+                    "API access may be unavailable or rate limited"
+                )
+            else:
+                log.info(f"   [ElsevierAPI] {route_name} HTTP {resp.status_code} for {doi}")
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(resp.content)
-        if is_pdf_file(output_path):
-            log.info(f"   [ElsevierAPI] downloaded {len(resp.content)} bytes for {doi}")
-            # Still persist cookies for future use by other strategies
+        if resp is not None and resp.status_code == 200 and _elsevier_response_is_pdf(resp):
+            result = _save_elsevier_pdf_content(
+                doi,
+                output_path,
+                resp.content,
+                config,
+                "ElsevierAPI",
+                reject_single_page=True,
+            )
+            if result:
+                try:
+                    _persist_api_cookies(session, config)
+                except Exception:
+                    pass
+                return result
+
+        result = _try_elsevier_object_pdf_from_xml(
+            doi,
+            output_path,
+            config,
+            session,
+            url,
+            headers,
+            resp,
+            full_xml_already_tried=True,
+        )
+        if result:
             try:
                 _persist_api_cookies(session, config)
             except Exception:
                 pass
-            return success(doi, output_path, "ElsevierAPI")
+            return result
 
-        output_path.unlink(missing_ok=True)
-        return None
-
-    # Non-PDF response (XML/JSON metadata) — API key lacks direct PDF access.
-    # Persist cookies from the redirect chain so browser strategy can reuse them.
-    log.info(f"   [ElsevierAPI] non-PDF response ({content_type[:50]}), persisting cookies")
-    try:
-        _persist_api_cookies(session, config)
-    except Exception as e:
-        log.info(f"   [ElsevierAPI] cookie persist failed: {e}")
+        content_type = _elsevier_header(
+            getattr(resp, "headers", {}) if resp is not None else {},
+            "content-type",
+        )
+        log.info(
+            f"   [ElsevierAPI] {route_name} non-PDF response "
+            f"({content_type[:50]}), trying next route if available"
+        )
+        try:
+            _persist_api_cookies(session, config)
+        except Exception as e:
+            log.info(f"   [ElsevierAPI] cookie persist failed: {e}")
 
     return None
 

--- a/src/scansci_pdf/server.py
+++ b/src/scansci_pdf/server.py
@@ -401,24 +401,52 @@ def scansci_pdf_elsevier_setup(test: bool = False) -> str:
         result["message"] = "Elsevier API key 已配置。"
 
         if test:
-            # Validate by hitting the serial title API (lightweight, no PDF download)
+            # Validate by hitting the serial title API (lightweight, no PDF download).
+            # Try direct first so campus/VPN routes are not hidden by a generic proxy.
             import requests
             from .network import USER_AGENT
             try:
-                s = requests.Session()
-                s.trust_env = False
                 proxy = config.get("network_proxy", "")
+                route_options: list[tuple[str, dict[str, str]]] = [("direct", {})]
                 if proxy:
-                    s.proxies = {"http": proxy, "https": proxy}
-                resp = s.get(
-                    "https://api.elsevier.com/content/serial/title",
-                    headers={"Accept": "application/json", "X-ELS-APIKey": api_key, "User-Agent": USER_AGENT},
-                    params={"count": 1},
-                    timeout=15,
-                )
+                    route_options.append(("configured_proxy", {"http": proxy, "https": proxy}))
+
+                resp = None
+                route_used = ""
+                last_error = ""
+                for route_name, proxies in route_options:
+                    try:
+                        s = requests.Session()
+                        s.trust_env = False
+                        if proxies:
+                            s.proxies = proxies
+                        candidate = s.get(
+                            "https://api.elsevier.com/content/serial/title",
+                            headers={
+                                "Accept": "application/json",
+                                "X-ELS-APIKey": api_key,
+                                "User-Agent": USER_AGENT,
+                            },
+                            params={"count": 1},
+                            timeout=15,
+                        )
+                        resp = candidate
+                        route_used = route_name
+                        if candidate.status_code == 200:
+                            break
+                    except Exception as route_exc:
+                        last_error = str(route_exc)
+
+                if resp is None:
+                    raise RuntimeError(last_error or "no Elsevier API response")
+
+                result["route"] = route_used
                 if resp.status_code == 200:
                     result["test"] = "passed"
-                    result["message"] += " API Key 验证有效！ScienceDirect 论文可直接 API 下载。"
+                    result["message"] += (
+                        " API Key 验证有效。闭源全文还需要机构订阅/IP entitlement；"
+                        "下载时会优先走 direct route，再回退配置代理。"
+                    )
                 else:
                     result["test"] = "failed"
                     result["message"] += f" API Key 验证失败（HTTP {resp.status_code}），请检查 key 是否正确。"
@@ -440,12 +468,15 @@ def scansci_pdf_elsevier_setup(test: bool = False) -> str:
             "Elsevier API Key 未配置。请按以下步骤操作：\n\n"
             "1. 浏览器已打开 Elsevier Developer Portal（如未打开请访问 https://dev.elsevier.com/）\n"
             "2. 注册或登录你的 Elsevier 账号（个人邮箱即可，免费）\n"
-            "3. 点击 \"My API Key\" → \"Create new key\"\n"
-            "4. 应用名称随意填写，选择 \"ScienceDirect Article Retrieval\" API\n"
-            "5. 复制生成的 API Key（32位字符串）\n"
+            "3. 进入 \"My API Key\" / API Key Settings，创建新的 API Key\n"
+            "4. 如需选择产品/API，选择 ScienceDirect / Article Retrieval 相关权限\n"
+            "5. 复制生成的 API Key\n"
             "6. 运行配置命令：\n"
             "   scansci_pdf_config_set(key=\"elsevier_api_key\", value=\"你的APIKey\")\n\n"
-            "配置后所有 Elsevier/ScienceDirect/Cell Press 论文自动走 API 直接下载（1-2秒）。"
+            "配置后，Elsevier/ScienceDirect/Cell Press 论文会优先走 API："
+            "view=FULL 全文 XML → 解析 PDF attachment-eid → object/eid 下载正式 PDF。\n"
+            "闭源全文仍取决于机构订阅和请求 IP；校园网/规则 VPN 用户应让 api.elsevier.com 走机构出口，"
+            "不要让普通 network_proxy 覆盖机构授权。"
         )
 
     return json.dumps(result, ensure_ascii=False, indent=2)

--- a/src/scansci_pdf/sources/elsevier_api.py
+++ b/src/scansci_pdf/sources/elsevier_api.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import xml.etree.ElementTree as ET
+from urllib.parse import quote
 
 import requests
 
@@ -47,9 +48,166 @@ def fetch_pdf(doi: str, api_key: str, inst_token: str = "") -> bytes | None:
     return _fetch_pdf_direct(doi, api_key, inst_token)
 
 
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1].split(":", 1)[-1].lower()
+
+
+def _element_text(el: ET.Element) -> str:
+    return " ".join(" ".join(el.itertext()).split())
+
+
+def _header(headers: dict, name: str) -> str:
+    value = headers.get(name)
+    if value is not None:
+        return str(value)
+    needle = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == needle:
+            return str(value)
+    return ""
+
+
+def _response_is_pdf(resp: requests.Response) -> bool:
+    content_type = _header(resp.headers, "content-type").lower()
+    return "pdf" in content_type or resp.content[:5] == b"%PDF-"
+
+
+def _looks_like_pdf_eid(value: str) -> bool:
+    lowered = value.strip().lower()
+    return bool(lowered) and (lowered.endswith(".pdf") or ".pdf" in lowered)
+
+
+def _article_eid_to_main_pdf(value: str) -> str:
+    candidate = value.strip()
+    if candidate.lower().startswith("eid:"):
+        candidate = candidate.split(":", 1)[1].strip()
+    if not candidate.startswith("1-s2.0-"):
+        return ""
+    if candidate.lower().endswith(".pdf"):
+        return candidate
+    return f"{candidate}-main.pdf"
+
+
+def _attachment_container(el: ET.Element, parent_map: dict[ET.Element, ET.Element]) -> ET.Element:
+    node = parent_map.get(el, el)
+    while node is not None:
+        local = _local_name(str(node.tag))
+        if "attachment" in local or "object" in local or local == "web-pdf":
+            return node
+        node = parent_map.get(node)
+    return parent_map.get(el, el)
+
+
+def _attachment_metadata(el: ET.Element) -> str:
+    parts: list[str] = []
+    for node in el.iter():
+        local = _local_name(str(node.tag))
+        text = _element_text(node)
+        if text:
+            parts.append(f"{local}:{text}")
+        for attr_name, attr_value in node.attrib.items():
+            attr_local = _local_name(str(attr_name))
+            if attr_value:
+                parts.append(f"{attr_local}:{attr_value}")
+    return " ".join(parts).lower()
+
+
+def _attachment_score(eid: str, metadata: str) -> int:
+    haystack = f"{eid} {metadata}".lower()
+    score = 0
+    if eid.lower().endswith(".pdf"):
+        score += 20
+    if "pdf" in haystack:
+        score += 10
+    if "main" in haystack or "full-text" in haystack or "fulltext" in haystack:
+        score += 100
+    if "page-count" in haystack or "pages" in haystack:
+        score += 5
+    if "attachment-size" in haystack or "filesize" in haystack or "file-size" in haystack:
+        score += 5
+    if any(
+        marker in haystack
+        for marker in ("supplement", "supplementary", "mmc", "appendix", "graphical")
+    ):
+        score -= 100
+    return score
+
+
+def _extract_pdf_attachment_eids(xml_text: str) -> list[str]:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        logger.warning("Failed to parse Elsevier XML attachments: %s", e)
+        return []
+
+    parent_map = {child: parent for parent in root.iter() for child in parent}
+    candidates: list[tuple[int, int, str]] = []
+    seen: set[str] = set()
+
+    for el in root.iter():
+        local = _local_name(str(el.tag))
+        found: list[str] = []
+
+        if local in {"attachment-eid", "object-eid"}:
+            text = _element_text(el)
+            if _looks_like_pdf_eid(text):
+                found.append(text)
+        elif local in {"eid", "identifier"}:
+            main_pdf = _article_eid_to_main_pdf(_element_text(el))
+            if main_pdf:
+                found.append(main_pdf)
+
+        for attr_name, attr_value in el.attrib.items():
+            attr_local = _local_name(str(attr_name))
+            if attr_local in {"attachment-eid", "object-eid", "eid"}:
+                value = str(attr_value).strip()
+                if _looks_like_pdf_eid(value):
+                    found.append(value)
+                else:
+                    main_pdf = _article_eid_to_main_pdf(value)
+                    if main_pdf:
+                        found.append(main_pdf)
+
+        for eid in found:
+            if eid in seen:
+                continue
+            seen.add(eid)
+            metadata = _attachment_metadata(_attachment_container(el, parent_map))
+            candidates.append((_attachment_score(eid, metadata), len(candidates), eid))
+
+    candidates.sort(key=lambda item: (-item[0], item[1]))
+    return [eid for _, _, eid in candidates]
+
+
+def _pdf_page_count(content: bytes) -> int | None:
+    try:
+        import fitz  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    try:
+        with fitz.open(stream=content, filetype="pdf") as doc:
+            return int(doc.page_count)
+    except Exception:
+        return None
+
+
+def _valid_pdf_bytes(content: bytes, label: str, *, reject_single_page: bool) -> bool:
+    if content[:5] != b"%PDF-":
+        logger.info("Elsevier API: %s returned non-PDF", label)
+        return False
+    if len(content) < 10000:
+        logger.warning("Elsevier API: %s too small (%d bytes)", label, len(content))
+        return False
+    if reject_single_page and _pdf_page_count(content) == 1:
+        logger.info("Elsevier API: %s is a 1-page preview", label)
+        return False
+    return True
+
+
 def _fetch_attachment_eids(doi: str, api_key: str, inst_token: str = "") -> list[str]:
     """Fetch FULL XML and extract MAIN PDF attachment EIDs."""
-    url = f"{ELSEVIER_API}/article/doi/{doi}?view=FULL"
+    url = f"{ELSEVIER_API}/article/doi/{doi}"
     headers = {
         "X-ELS-APIKey": api_key,
         "Accept": "application/xml",
@@ -57,46 +215,19 @@ def _fetch_attachment_eids(doi: str, api_key: str, inst_token: str = "") -> list
     if inst_token:
         headers["X-ELS-InstToken"] = inst_token
 
-    resp = _api_request(url, headers)
+    resp = _api_request(url, headers, params={"view": "FULL"})
     if not resp or resp.status_code != 200:
         return []
 
-    # Parse XML to find attachment EIDs
-    eids = []
-    try:
-        import xml.etree.ElementTree as ET
-        root = ET.fromstring(resp.text)
-        for el in root.iter():
-            local = el.tag.split("}")[-1] if "}" in el.tag else el.tag
-            if local == "web-pdf":
-                eid = ""
-                purpose = ""
-                page_count = 0
-                for child in el:
-                    child_local = child.tag.split("}")[-1] if "}" in child.tag else child.tag
-                    if child_local == "attachment-eid" and child.text:
-                        eid = child.text.strip()
-                    elif child_local == "web-pdf-purpose" and child.text:
-                        purpose = child.text.strip()
-                    elif child_local == "web-pdf-page-count" and child.text:
-                        try:
-                            page_count = int(child.text.strip())
-                        except ValueError:
-                            pass
-                if eid and purpose == "MAIN":
-                    eids.append(eid)
-                    logger.info("Elsevier API: found MAIN attachment %s (%d pages)", eid, page_count)
-    except Exception as e:
-        logger.warning("Failed to parse Elsevier XML attachments: %s", e)
-
-    # Sort: prefer main.pdf over mainext.pdf
-    eids.sort(key=lambda e: (0 if e.endswith("-main.pdf") else 1))
+    eids = _extract_pdf_attachment_eids(resp.text)
+    for eid in eids:
+        logger.info("Elsevier API: found PDF attachment %s", eid)
     return eids
 
 
 def _fetch_pdf_by_eid(eid: str, api_key: str, inst_token: str = "") -> bytes | None:
     """Download PDF via Content Object API using attachment EID."""
-    url = f"{ELSEVIER_API}/object/eid/{eid}"
+    url = f"{ELSEVIER_API}/object/eid/{quote(eid, safe='')}"
     headers = {
         "X-ELS-APIKey": api_key,
         "Accept": "application/pdf",
@@ -116,12 +247,11 @@ def _fetch_pdf_by_eid(eid: str, api_key: str, inst_token: str = "") -> bytes | N
         logger.info("Elsevier API: HTTP %d for attachment %s", resp.status_code, eid)
         return None
 
-    if resp.content[:5] != b"%PDF-":
+    if not _response_is_pdf(resp):
         logger.info("Elsevier API: attachment %s returned non-PDF", eid)
         return None
 
-    if len(resp.content) < 10000:
-        logger.warning("Elsevier API: attachment %s too small (%d bytes)", eid, len(resp.content))
+    if not _valid_pdf_bytes(resp.content, f"attachment {eid}", reject_single_page=True):
         return None
 
     logger.info("Elsevier API: downloaded %d bytes via attachment %s", len(resp.content), eid)
@@ -142,30 +272,47 @@ def _fetch_pdf_direct(doi: str, api_key: str, inst_token: str = "") -> bytes | N
     if not resp or resp.status_code != 200:
         return None
 
-    content_type = resp.headers.get("content-type", "")
-    if "pdf" not in content_type and resp.content[:5] != b"%PDF-":
+    content_type = _header(resp.headers, "content-type")
+    if not _response_is_pdf(resp):
         logger.info("Elsevier API: direct endpoint returned non-PDF (%s)", content_type[:50])
         return None
 
-    if len(resp.content) < 10000:
-        logger.warning("Elsevier API: direct PDF too small (%d bytes)", len(resp.content))
+    if not _valid_pdf_bytes(resp.content, "direct PDF", reject_single_page=True):
         return None
 
     logger.info("Elsevier API: downloaded %d bytes directly for %s", len(resp.content), doi)
     return resp.content
 
 
-def _api_request(url: str, headers: dict) -> requests.Response | None:
+def _api_request(
+    url: str,
+    headers: dict,
+    *,
+    params: dict[str, str] | None = None,
+) -> requests.Response | None:
     """Make an Elsevier API request with error handling."""
     try:
         session = requests.Session()
         session.trust_env = False
-        resp = session.get(url, headers=headers, timeout=30, allow_redirects=True)
+        resp = session.get(
+            url,
+            headers=headers,
+            params=params,
+            timeout=30,
+            allow_redirects=True,
+        )
     except requests.exceptions.SSLError:
         try:
             session = requests.Session()
             session.trust_env = False
-            resp = session.get(url, headers=headers, timeout=30, allow_redirects=True, verify=False)
+            resp = session.get(
+                url,
+                headers=headers,
+                params=params,
+                timeout=30,
+                allow_redirects=True,
+                verify=False,
+            )
         except requests.RequestException as e:
             logger.warning("Elsevier API request failed: %s", e)
             return None
@@ -194,18 +341,8 @@ def fetch_fulltext(doi: str, api_key: str, inst_token: str = "") -> dict | None:
     if inst_token:
         headers["X-ELS-Insttoken"] = inst_token
 
-    try:
-        session = requests.Session()
-        session.trust_env = False
-        resp = session.get(url, headers=headers, timeout=30, allow_redirects=True)
-    except requests.exceptions.SSLError:
-        try:
-            resp = session.get(url, headers=headers, timeout=30, allow_redirects=True, verify=False)
-        except requests.RequestException as e:
-            logger.warning("Elsevier API request failed: %s", e)
-            return None
-    except requests.RequestException as e:
-        logger.warning("Elsevier API request failed: %s", e)
+    resp = _api_request(url, headers, params={"view": "FULL"})
+    if not resp:
         return None
 
     if resp.status_code == 401:

--- a/tests/test_elsevier_api.py
+++ b/tests/test_elsevier_api.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_elsevier_api_downloads_main_pdf_from_xml_attachment_eid(
+    monkeypatch, tmp_path: Path
+):
+    import requests
+
+    from scansci_pdf.publisher_strategies import try_elsevier_api
+
+    pdf_bytes = b"%PDF-1.4\n" + (b"0" * 1200) + b"\n%%EOF\n"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response xmlns:xocs="http://www.elsevier.com/xml/xocs/dtd">
+      <xocs:attachment>
+        <xocs:attachment-type>PDF</xocs:attachment-type>
+        <xocs:attachment-eid>1-s2.0-S0006320725007013-main.pdf</xocs:attachment-eid>
+        <xocs:attachment-category>MAIN</xocs:attachment-category>
+        <xocs:attachment-size>11219763</xocs:attachment-size>
+        <xocs:attachment-page-count>14</xocs:attachment-page-count>
+      </xocs:attachment>
+      <xocs:attachment>
+        <xocs:attachment-type>PDF</xocs:attachment-type>
+        <xocs:attachment-eid>1-s2.0-S0006320725007013-mmc1.pdf</xocs:attachment-eid>
+        <xocs:attachment-category>SUPPLEMENTARY</xocs:attachment-category>
+      </xocs:attachment>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        def __init__(self, content: bytes, content_type: str):
+            self.status_code = 200
+            self.content = content
+            self.headers = {"Content-Type": content_type, "X-ELS-Status": "OK"}
+            self.text = content.decode("utf-8", errors="replace")
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = []
+            self.calls: list[tuple[str, dict]] = []
+
+        def get(self, url, *, headers=None, **kwargs):
+            self.calls.append((url, {"headers": dict(headers or {}), **kwargs}))
+            if len(self.calls) == 1:
+                return FakeResponse(xml.encode("utf-8"), "application/xml")
+            return FakeResponse(pdf_bytes, "application/pdf")
+
+    session = FakeSession()
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    output_path = tmp_path / "elsevier.pdf"
+    result = try_elsevier_api(
+        "10.1016/j.biocon.2025.111664",
+        output_path,
+        {"elsevier_api_key": "test-key", "min_pdf_size_bytes": 1000},
+    )
+
+    assert result is not None
+    assert result["success"] is True
+    assert output_path.read_bytes() == pdf_bytes
+    assert session.calls[0][0] == (
+        "https://api.elsevier.com/content/article/doi/"
+        "10.1016/j.biocon.2025.111664"
+    )
+    assert session.calls[0][1]["headers"]["Accept"] == "application/xml"
+    assert session.calls[0][1]["params"] == {"view": "FULL"}
+    assert session.calls[1][0] == (
+        "https://api.elsevier.com/content/object/eid/"
+        "1-s2.0-S0006320725007013-main.pdf"
+    )
+    assert session.calls[1][1]["headers"]["Accept"] == "application/pdf"
+
+
+def test_elsevier_api_falls_back_to_default_xml_when_full_xml_is_denied(
+    monkeypatch, tmp_path: Path
+):
+    import requests
+
+    from scansci_pdf.publisher_strategies import try_elsevier_api
+
+    pdf_bytes = b"%PDF-1.4\n" + (b"1" * 1200) + b"\n%%EOF\n"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <attachment>
+        <attachment-type>PDF</attachment-type>
+        <attachment-eid>1-s2.0-S0006320725007013-main.pdf</attachment-eid>
+        <attachment-category>MAIN</attachment-category>
+      </attachment>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        def __init__(self, content: bytes, content_type: str, status_code: int = 200):
+            self.status_code = status_code
+            self.content = content
+            self.headers = {"Content-Type": content_type, "X-ELS-Status": "OK"}
+            self.text = content.decode("utf-8", errors="replace")
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = []
+            self.calls: list[tuple[str, dict]] = []
+
+        def get(self, url, *, headers=None, **kwargs):
+            self.calls.append((url, {"headers": dict(headers or {}), **kwargs}))
+            if len(self.calls) == 1:
+                return FakeResponse(
+                    b"<error>view denied</error>",
+                    "application/xml",
+                    status_code=400,
+                )
+            if len(self.calls) == 2:
+                return FakeResponse(xml.encode("utf-8"), "application/xml")
+            return FakeResponse(pdf_bytes, "application/pdf")
+
+    session = FakeSession()
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    output_path = tmp_path / "elsevier.pdf"
+    result = try_elsevier_api(
+        "10.1016/j.biocon.2025.111664",
+        output_path,
+        {"elsevier_api_key": "test-key", "min_pdf_size_bytes": 1000},
+    )
+
+    assert result is not None
+    assert output_path.read_bytes() == pdf_bytes
+    assert [call[1]["headers"]["Accept"] for call in session.calls] == [
+        "application/xml",
+        "application/xml",
+        "application/pdf",
+    ]
+    assert session.calls[0][1]["params"] == {"view": "FULL"}
+    assert "params" not in session.calls[1][1]
+    assert session.calls[2][0] == (
+        "https://api.elsevier.com/content/object/eid/"
+        "1-s2.0-S0006320725007013-main.pdf"
+    )
+
+
+def test_elsevier_api_requests_full_xml_view_before_object_download(
+    monkeypatch, tmp_path: Path
+):
+    import requests
+
+    from scansci_pdf.publisher_strategies import try_elsevier_api
+
+    pdf_bytes = b"%PDF-1.4\n" + (b"fulltext" * 200) + b"\n%%EOF\n"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <web-pdf>
+        <attachment-eid>1-s2.0-S0006320725007013-main.pdf</attachment-eid>
+        <filesize>10710588</filesize>
+        <web-pdf-purpose>MAIN</web-pdf-purpose>
+        <web-pdf-page-count>14</web-pdf-page-count>
+      </web-pdf>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        def __init__(self, content: bytes, content_type: str):
+            self.status_code = 200
+            self.content = content
+            self.headers = {"Content-Type": content_type, "X-ELS-Status": "OK"}
+            self.text = content.decode("utf-8", errors="replace")
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = []
+            self.calls: list[tuple[str, dict]] = []
+
+        def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            if len(self.calls) == 1:
+                return FakeResponse(xml.encode("utf-8"), "application/xml")
+            return FakeResponse(pdf_bytes, "application/pdf")
+
+    session = FakeSession()
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    result = try_elsevier_api(
+        "10.1016/j.biocon.2025.111664",
+        tmp_path / "elsevier.pdf",
+        {"elsevier_api_key": "test-key", "min_pdf_size_bytes": 1000},
+    )
+
+    assert result is not None
+    assert session.calls[0][1]["params"] == {"view": "FULL"}
+    assert session.calls[0][1]["headers"]["Accept"] == "application/xml"
+
+
+def test_elsevier_api_rejects_single_page_object_pdf(
+    monkeypatch, tmp_path: Path
+):
+    import requests
+
+    import scansci_pdf.publisher_strategies as strategies
+
+    preview_pdf = b"%PDF-1.4\n" + (b"preview" * 200) + b"\n%%EOF\n"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <attachment>
+        <attachment-type>PDF</attachment-type>
+        <attachment-eid>1-s2.0-S0006320725007013-main.pdf</attachment-eid>
+        <attachment-category>MAIN</attachment-category>
+      </attachment>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        def __init__(self, content: bytes, content_type: str):
+            self.status_code = 200
+            self.content = content
+            self.headers = {"Content-Type": content_type, "X-ELS-Status": "OK"}
+            self.text = content.decode("utf-8", errors="replace")
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = []
+            self.calls: list[tuple[str, dict]] = []
+
+        def get(self, url, *, headers=None, **kwargs):
+            self.calls.append((url, {"headers": dict(headers or {}), **kwargs}))
+            if len(self.calls) == 1:
+                return FakeResponse(xml.encode("utf-8"), "application/xml")
+            return FakeResponse(preview_pdf, "application/pdf")
+
+    monkeypatch.setattr(strategies, "_elsevier_pdf_page_count", lambda _content: 1)
+
+    session = FakeSession()
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    output_path = tmp_path / "elsevier.pdf"
+    result = strategies.try_elsevier_api(
+        "10.1016/j.biocon.2025.111664",
+        output_path,
+        {"elsevier_api_key": "test-key", "min_pdf_size_bytes": 1000},
+    )
+
+    assert result is None
+    assert not output_path.exists()
+    assert [call[1]["headers"]["Accept"] for call in session.calls] == [
+        "application/xml",
+        "application/pdf",
+    ]
+
+
+def test_elsevier_xml_uses_article_eid_main_pdf_when_attachment_eid_is_absent():
+    from scansci_pdf.publisher_strategies import _extract_elsevier_pdf_attachment_eids
+
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <coredata>
+        <eid>1-s2.0-S0006320725007013</eid>
+        <pii>S0006-3207(25)00701-3</pii>
+      </coredata>
+    </full-text-retrieval-response>
+    """
+
+    assert _extract_elsevier_pdf_attachment_eids(xml) == [
+        "1-s2.0-S0006320725007013-main.pdf"
+    ]
+
+
+def test_elsevier_api_prefers_direct_route_over_configured_proxy(
+    monkeypatch, tmp_path: Path
+):
+    import requests
+
+    from scansci_pdf.publisher_strategies import try_elsevier_api
+
+    pdf_bytes = b"%PDF-1.4\n" + (b"fulltext" * 200) + b"\n%%EOF\n"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <attachment>
+        <attachment-type>PDF</attachment-type>
+        <attachment-eid>1-s2.0-S0006320725007013-main.pdf</attachment-eid>
+        <attachment-category>MAIN</attachment-category>
+      </attachment>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        def __init__(self, content: bytes, content_type: str, status_code: int = 200):
+            self.status_code = status_code
+            self.content = content
+            self.headers = {"Content-Type": content_type, "X-ELS-Status": "OK"}
+            self.text = content.decode("utf-8", errors="replace")
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = []
+            self.proxies = {}
+            self.calls = []
+
+        def get(self, url, *, headers=None, **kwargs):
+            self.calls.append((url, {"headers": dict(headers or {}), **kwargs}))
+            if len(self.calls) == 1:
+                return FakeResponse(xml.encode("utf-8"), "application/xml")
+            return FakeResponse(pdf_bytes, "application/pdf")
+
+    sessions: list[FakeSession] = []
+
+    def session_factory():
+        session = FakeSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(requests, "Session", session_factory)
+
+    result = try_elsevier_api(
+        "10.1016/j.biocon.2025.111664",
+        tmp_path / "elsevier.pdf",
+        {
+            "elsevier_api_key": "test-key",
+            "network_proxy": "http://127.0.0.1:7890",
+            "min_pdf_size_bytes": 1000,
+        },
+    )
+
+    assert result is not None
+    assert len(sessions) == 1
+    assert sessions[0].trust_env is False
+    assert sessions[0].proxies == {}
+
+
+def test_elsevier_api_falls_back_to_configured_proxy_when_direct_not_entitled(
+    monkeypatch, tmp_path: Path
+):
+    import requests
+
+    from scansci_pdf.publisher_strategies import try_elsevier_api
+
+    pdf_bytes = b"%PDF-1.4\n" + (b"fulltext" * 200) + b"\n%%EOF\n"
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <attachment>
+        <attachment-type>PDF</attachment-type>
+        <attachment-eid>1-s2.0-S0006320725007013-main.pdf</attachment-eid>
+        <attachment-category>MAIN</attachment-category>
+      </attachment>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        def __init__(self, content: bytes, content_type: str, status_code: int = 200):
+            self.status_code = status_code
+            self.content = content
+            self.headers = {"Content-Type": content_type, "X-ELS-Status": "OK"}
+            self.text = content.decode("utf-8", errors="replace")
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = []
+            self.proxies = {}
+            self.calls = []
+            self.index = len(sessions)
+
+        def get(self, url, *, headers=None, **kwargs):
+            self.calls.append((url, {"headers": dict(headers or {}), **kwargs}))
+            if self.index == 0:
+                return FakeResponse(
+                    b"<service-error>not entitled</service-error>",
+                    "application/xml",
+                    status_code=401,
+                )
+            if len(self.calls) == 1:
+                return FakeResponse(xml.encode("utf-8"), "application/xml")
+            return FakeResponse(pdf_bytes, "application/pdf")
+
+    sessions: list[FakeSession] = []
+
+    def session_factory():
+        session = FakeSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(requests, "Session", session_factory)
+
+    result = try_elsevier_api(
+        "10.1016/j.biocon.2025.111664",
+        tmp_path / "elsevier.pdf",
+        {
+            "elsevier_api_key": "test-key",
+            "network_proxy": "http://127.0.0.1:7890",
+            "min_pdf_size_bytes": 1000,
+        },
+    )
+
+    assert result is not None
+    assert len(sessions) == 2
+    assert sessions[0].trust_env is False
+    assert sessions[0].proxies == {}
+    assert sessions[1].trust_env is False
+    assert sessions[1].proxies == {
+        "http": "http://127.0.0.1:7890",
+        "https": "http://127.0.0.1:7890",
+    }

--- a/tests/test_elsevier_source_api.py
+++ b/tests/test_elsevier_source_api.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+
+def test_source_fetch_pdf_downloads_attachment_from_full_xml(monkeypatch):
+    from scansci_pdf.sources import elsevier_api
+
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response xmlns:xocs="http://www.elsevier.com/xml/xocs/dtd">
+      <xocs:attachment>
+        <xocs:attachment-type>PDF</xocs:attachment-type>
+        <xocs:attachment-eid>1-s2.0-S0006320725007013-main.pdf</xocs:attachment-eid>
+        <xocs:attachment-category>MAIN</xocs:attachment-category>
+        <xocs:attachment-page-count>14</xocs:attachment-page-count>
+      </xocs:attachment>
+    </full-text-retrieval-response>
+    """
+    pdf_bytes = b"%PDF-1.7\n" + (b"official" * 2000) + b"\n%%EOF\n"
+
+    class FakeResponse:
+        def __init__(self, status_code, content, content_type):
+            self.status_code = status_code
+            self.content = content
+            self.text = content.decode("utf-8", errors="replace")
+            self.headers = {"content-type": content_type}
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            if len(self.calls) == 1:
+                return FakeResponse(200, xml.encode("utf-8"), "application/xml")
+            if len(self.calls) == 2:
+                return FakeResponse(200, pdf_bytes, "application/pdf")
+            return FakeResponse(404, b"", "text/plain")
+
+    session = FakeSession()
+    monkeypatch.setattr(elsevier_api.requests, "Session", lambda: session)
+    monkeypatch.setattr(elsevier_api, "_pdf_page_count", lambda _content: 14, raising=False)
+
+    assert elsevier_api.fetch_pdf("10.1016/j.biocon.2025.111664", "test-key") == pdf_bytes
+    assert session.trust_env is False
+    assert session.calls[0][0].endswith(
+        "/article/doi/10.1016/j.biocon.2025.111664"
+    )
+    assert session.calls[0][1]["params"] == {"view": "FULL"}
+    assert session.calls[0][1]["headers"]["Accept"] == "application/xml"
+    assert session.calls[1][0].endswith(
+        "/object/eid/1-s2.0-S0006320725007013-main.pdf"
+    )
+    assert session.calls[1][1]["headers"]["Accept"] == "application/pdf"
+
+
+def test_source_fetch_pdf_rejects_single_page_direct_preview(monkeypatch):
+    from scansci_pdf.sources import elsevier_api
+
+    preview_pdf = b"%PDF-1.7\n" + (b"preview" * 2000) + b"\n%%EOF\n"
+
+    class FakeResponse:
+        def __init__(self, status_code, content, content_type):
+            self.status_code = status_code
+            self.content = content
+            self.text = content.decode("utf-8", errors="replace")
+            self.headers = {"content-type": content_type}
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            if len(self.calls) == 1:
+                return FakeResponse(400, b"<error>not entitled</error>", "application/xml")
+            return FakeResponse(200, preview_pdf, "application/pdf")
+
+    session = FakeSession()
+    monkeypatch.setattr(elsevier_api.requests, "Session", lambda: session)
+    monkeypatch.setattr(elsevier_api, "_pdf_page_count", lambda _content: 1, raising=False)
+
+    assert elsevier_api.fetch_pdf("10.1016/j.biocon.2025.111664", "test-key") is None
+
+
+def test_source_fetch_fulltext_requests_full_xml_view(monkeypatch):
+    from scansci_pdf.sources import elsevier_api
+
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <full-text-retrieval-response>
+      <originalText>
+        <doc>
+          <body>
+            <section>
+              <section-title>Introduction</section-title>
+              <para>Full XML body.</para>
+            </section>
+          </body>
+        </doc>
+      </originalText>
+    </full-text-retrieval-response>
+    """
+
+    class FakeResponse:
+        status_code = 200
+        content = xml.encode("utf-8")
+        text = xml
+        headers = {"content-type": "application/xml"}
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            return FakeResponse()
+
+    session = FakeSession()
+    monkeypatch.setattr(elsevier_api.requests, "Session", lambda: session)
+
+    data = elsevier_api.fetch_fulltext(
+        "10.1016/j.nicl.2021.102600",
+        api_key="test-key",
+    )
+
+    assert data is not None
+    assert "Full XML body" in data["full_text"]
+    assert session.calls[0][1]["params"] == {"view": "FULL"}
+    assert session.calls[0][1]["headers"]["Accept"] == "application/xml"


### PR DESCRIPTION
## Summary
- implement Elsevier full-text XML -> Content Object API PDF retrieval with direct-first routing
- reject one-page Elsevier preview PDFs and add coverage for object/eid behavior
- refresh user-facing README and scansci-pdf skill guidance for Elsevier API setup
- document the successful Elsevier workflow and 10-article smoke test

## Validation
- python -m pytest tests\test_elsevier_api.py tests\test_elsevier_source_api.py tests\test_browser_doctor.py -q
- python -m py_compile src\scansci_pdf\publisher_strategies.py src\scansci_pdf\sources\elsevier_api.py src\scansci_pdf\server.py src\scansci_pdf\cli.py src\scansci_pdf\main.py tests\test_elsevier_api.py tests\test_elsevier_source_api.py
- PYTHONUTF8=1 python C:\Users\Liang\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\scansci-pdf\skill