### PR TITLE
fix: support MCP Python SDK 2.x (FastMCP renamed to MCPServer)

### DIFF
--- a/src/scansci_pdf/mcp_server.py
+++ b/src/scansci_pdf/mcp_server.py
@@ -3,7 +3,10 @@
 import logging
 import sys
 
-from mcp.server.fastmcp import FastMCP
+try:  # MCP SDK >= 2.0 renamed FastMCP to MCPServer
+    from mcp.server.mcpserver import MCPServer as FastMCP
+except ImportError:  # MCP SDK 1.x
+    from mcp.server.fastmcp import FastMCP
 
 from .config import load_config, save_config
 from .institutional.config_adapter import ConfigAdapter

--- a/src/scansci_pdf/server.py
+++ b/src/scansci_pdf/server.py
@@ -7,7 +7,10 @@ import time
 from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+try:  # MCP SDK >= 2.0 renamed FastMCP to MCPServer
+    from mcp.server.mcpserver import MCPServer as FastMCP
+except ImportError:  # MCP SDK 1.x
+    from mcp.server.fastmcp import FastMCP
 
 from .cache import cache_clear, cache_get
 from .config import get_config_safe, load_config, update_config


### PR DESCRIPTION
Closes #40. Closes #42.

## Problem

MCP SDK 2.0 moved `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer` ([migration guide](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md#fastmcp-renamed-to-mcpserver)). `pyproject.toml` declares `mcp[cli]>=1.12` with no upper bound, so any fresh install resolves to `mcp==2.0.0` and `scansci-pdf run` dies at import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
  File ".../scansci_pdf/server.py", line 10
```

## Approach

Both issues suggest pinning `mcp[cli]>=1.12,<2`. That unblocks users but leaves the project stuck on SDK 1.x. This PR migrates instead, while keeping 1.x working:

```python
try:  # MCP SDK >= 2.0 renamed FastMCP to MCPServer
    from mcp.server.mcpserver import MCPServer as FastMCP
except ImportError:  # MCP SDK 1.x
    from mcp.server.fastmcp import FastMCP
```

Binding `MCPServer` to the existing local name `FastMCP` means **no call site changes**. I checked every API this repo uses against `MCPServer`, and all are unchanged:

| Usage | Site | `MCPServer` |
|---|---|---|
| `FastMCP(name=..., instructions=...)` | `server.py:21` | same kwargs |
| `FastMCP("scansci-pdf")` | `mcp_server.py:21` | first positional is `name` |
| `@mcp_app.tool()` × 45 | `server.py` | `.tool()` same signature |
| `.run(transport="stdio")` | `main.py:37`, `mcp_server.py:176` | same signature |
| `.streamable_http_app()` | `main.py:50` | present |

No dependency bound is needed — the shim covers both majors.

## Verification

Two clean venvs, editable install of this branch, Python 3.13:

| | `mcp==1.29.0` | `mcp==2.0.0` |
|---|---|---|
| `import scansci_pdf.server` | OK | OK |
| Base class | `FastMCP` | `MCPServer` |
| `list_tools()` | 45 | 45 |
| stdio `initialize` | protocol `2025-06-18` | protocol `2025-06-18` |
| stdio `tools/list` | 45 tools | 45 tools |
| `import scansci_pdf.mcp_server` | OK | OK |

Handshake was a real JSON-RPC exchange against `scansci-pdf run` over stdio, not just an import check. Tool count is identical across both majors, so no tool is silently dropped.

`pytest tests/` on `mcp==1.29.0`, before and after the patch:

```
1 failed, 59 passed, 5 warnings, 1 error
```

Byte-identical results — the pre-existing `test_search_json_is_ascii_safe_and_contains_author_match` failure and `test_sso_publishers.py::test_publisher` error are unrelated to this change.

## Notes for maintainers, out of scope here

1. `serverInfo.version` differs between majors — 1.x reports the SDK version (`"1.29.0"`), 2.0 reports `""` because `MCPServer.__init__` defaults `version: str = ""`. Passing an explicit `version=` would make this consistent, but that is a behaviour change so I left it alone.
2. `src/scansci_pdf/mcp_server.py` has no inbound references (only entry point is `scansci_pdf.main:main`). I patched it anyway so no stale `mcp.server.fastmcp` import is left in the tree, but it may be dead code worth removing separately.
3. `pymupdf` is imported by `src/scansci_pdf/extractors/pdf_extractor.py` but not declared in `pyproject.toml`; `pytest tests/` fails at collection without it. Unrelated to this PR.
4. #42 also notes that `scansci-pdf check` reports `[OK] mcp` while the server cannot start. Making `check` actually import the server module would catch this class of breakage, but that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)