### PR TITLE
Fix Elsevier preview false-success, Sci-Hub interactive popup storm, and WebVPN loop leak in CLI cascades

### DIFF
--- a/src/scansci_pdf/_publisher_strategies_core.py
+++ b/src/scansci_pdf/_publisher_strategies_core.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import re
 import threading
 import time
@@ -2423,6 +2424,58 @@ def _try_elsevier_object_pdf_from_xml(
     return None
 
 
+def _try_elsevier_text_fallback(
+    doi: str,
+    output_path: Path,
+    session: Any,
+    article_url: str,
+    headers: dict[str, str],
+    config: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Last API resort: save the httpAccept=text/plain full text as .txt.
+
+    Only kept when the body is a real plain-text payload above 100KB — the
+    same threshold pdf_utils.is_suspicious_pdf treats as certainly full text —
+    so the racing pipeline never flags or drops the artifact. API error
+    payloads (text/xml) are rejected by the content-type check.
+    """
+    txt_headers = dict(headers)
+    txt_headers["Accept"] = "text/plain"
+    try:
+        resp = session.get(
+            article_url,
+            headers=txt_headers,
+            params={"httpAccept": "text/plain"},
+            timeout=30,
+            allow_redirects=True,
+        )
+    except Exception as e:
+        log.info(f"   [ElsevierAPI] text/plain request failed: {e}")
+        return None
+
+    if getattr(resp, "status_code", 0) != 200:
+        return None
+    content_type = _elsevier_header(getattr(resp, "headers", {}), "content-type").lower()
+    content = getattr(resp, "content", b"") or b""
+    if "text/plain" not in content_type or len(content) < 100_000:
+        log.info(
+            f"   [ElsevierAPI] no usable full text ({content_type[:40]}, "
+            f"{len(content)} bytes)"
+        )
+        return None
+
+    txt_path = output_path.with_suffix(".txt")
+    try:
+        txt_path.parent.mkdir(parents=True, exist_ok=True)
+        txt_path.write_bytes(content)
+    except OSError as e:
+        log.info(f"   [ElsevierAPI] full text save failed: {e}")
+        return None
+    log.info(f"   [ElsevierAPI] saved {len(content)} bytes of full text as {txt_path.name}")
+    from .pdf_utils import success
+    return success(doi, txt_path, "ElsevierAPI(Text)")
+
+
 def try_elsevier_api(
     doi: str, output_path: Path, config: dict[str, Any],
 ) -> dict[str, Any] | None:
@@ -2432,15 +2485,28 @@ def try_elsevier_api(
     and optional institutional token. This is far faster and more reliable
     than browser-based login flows.
 
+    API-first request order per route (browser navigation is only a last
+    resort and lives in try_elsevier_browser):
+      1. article endpoint with Accept: application/pdf — the full PDF when
+         the key's entitlement covers the article. Entitlement follows the
+         API key, not the client IP, so this works off-campus. The body is
+         validated as a real multi-page PDF before saving (rejects the
+         1-page preview served to unentitled keys).
+      2. FULL XML → main-PDF attachment EIDs → Content Object API
+         (existing chain; covers articles whose direct endpoint misbehaves).
+      3. httpAccept=text/plain full text saved as .txt when no PDF is
+         returned at all.
+
     When the API does not return a PDF directly (no institutional access),
-    cookies from the redirect chain (api.elsevier.com → linkinghub.elsevier.com
+    cookies from the request chain (api.elsevier.com → linkinghub.elsevier.com
     → sciencedirect.com) are persisted for the browser strategy to reuse.
 
     Config keys:
-        elsevier_api_key   — personal or institutional API key (required)
+        elsevier_api_key   — personal or institutional API key (required);
+                             falls back to the ELSEVIER_API_KEY env var
         elsevier_insttoken — institutional token for campus-level access
     """
-    api_key = config.get("elsevier_api_key", "")
+    api_key = config.get("elsevier_api_key", "") or os.environ.get("ELSEVIER_API_KEY", "")
     if not api_key:
         log.info(f"   [ElsevierAPI] no API key configured, skipping. "
                  f"Run scansci_pdf_elsevier_setup to configure (free).")
@@ -2467,13 +2533,45 @@ def try_elsevier_api(
     import requests
 
     for route_name, proxies in route_options:
-        try:
-            session = requests.Session()
-            session.trust_env = False
-            if proxies:
-                session.proxies = proxies
+        session = requests.Session()
+        session.trust_env = False
+        if proxies:
+            session.proxies = proxies
 
+        # Step 1: direct article PDF — entitlement follows the API key, so no
+        # campus IP is needed. Reject non-200 and 1-page preview responses.
+        pdf_headers = dict(headers)
+        pdf_headers["Accept"] = "application/pdf"
+        pdf_resp = None
+        try:
             log.info(f"   [ElsevierAPI] trying {route_name} route")
+            pdf_resp = session.get(
+                url,
+                headers=pdf_headers,
+                timeout=30,
+                allow_redirects=True,
+            )
+        except Exception as e:
+            log.info(f"   [ElsevierAPI] {route_name} direct PDF request failed: {e}")
+
+        if pdf_resp is not None and pdf_resp.status_code == 200 and _elsevier_response_is_pdf(pdf_resp):
+            result = _save_elsevier_pdf_content(
+                doi,
+                output_path,
+                pdf_resp.content,
+                config,
+                "ElsevierAPI",
+                reject_single_page=True,
+            )
+            if result:
+                return result
+        elif pdf_resp is not None and pdf_resp.status_code != 200:
+            log.info(
+                f"   [ElsevierAPI] {route_name} direct PDF HTTP "
+                f"{pdf_resp.status_code} for {doi}, trying FULL XML route"
+            )
+
+        try:
             xml_headers = dict(headers)
             xml_headers["Accept"] = "application/xml"
             resp = session.get(
@@ -2541,6 +2639,12 @@ def try_elsevier_api(
             _persist_api_cookies(session, config)
         except Exception as e:
             log.info(f"   [ElsevierAPI] cookie persist failed: {e}")
+
+        # Step 3: full text as .txt — the API returned no PDF deliverable for
+        # this DOI; grab the plain-text full text before falling back further.
+        txt_result = _try_elsevier_text_fallback(doi, output_path, session, url, headers, config)
+        if txt_result:
+            return txt_result
 
     return None
 # ============================================================

--- a/src/scansci_pdf/auth.py
+++ b/src/scansci_pdf/auth.py
@@ -85,6 +85,7 @@ class WebVPNAuth:
         config: dict,
         key: bytes | None = None,
         iv: bytes | None = None,
+        base_url: str = "",
     ):
         self.config = config
         self._encrypt_key = key or WEBVPN_DEFAULT_KEY
@@ -93,7 +94,7 @@ class WebVPNAuth:
         self._browser = None
         self._context = None
         self._page = None
-        base = config.get("instsci_base_url", "") or config.get("vpnsci_base_url", "")
+        base = base_url or config.get("instsci_base_url", "") or config.get("vpnsci_base_url", "")
         self._webvpn_base = base.rstrip("/") if base else ""
 
     @property
@@ -109,6 +110,23 @@ class WebVPNAuth:
             "--no-proxy-server",
             "--disable-features=CrossOriginOpenerPolicy",
         ]
+
+    def _close_browser_quietly(self) -> None:
+        """Close a launched persistent context and release its Playwright loop.
+
+        Skipping this leaks the sync dispatcher loop on the current thread;
+        every later launch in the same thread then fails with "Playwright Sync
+        API inside the asyncio loop" (seen in CLI fetch/batch cascades).
+        """
+        for attr in ("_page", "_context", "_browser"):
+            obj = getattr(self, attr, None)
+            if obj is None:
+                continue
+            try:
+                obj.close()
+            except Exception:
+                pass
+            setattr(self, attr, None)
 
     @property
     def session(self) -> requests.Session:
@@ -144,6 +162,12 @@ class WebVPNAuth:
 
         if not hostname:
             return url
+        if not self._webvpn_base:
+            # Never return a relative gateway URL — callers would navigate to
+            # "/https/77726476..." which is always an invalid URL.
+            raise ValueError(
+                "WebVPN base URL is empty — run `scansci-pdf setup <学校全名>` first"
+            )
 
         cipher = AES.new(self._encrypt_key, AES.MODE_CFB, self._encrypt_iv, segment_size=128)
         encrypted = cipher.encrypt(hostname.encode("utf-8"))
@@ -185,6 +209,8 @@ class WebVPNAuth:
         if proxy:
             test_url = TEST_URL
         else:
+            if not self._webvpn_base:
+                return False
             test_url = self.convert_url(TEST_URL)
         try:
             resp = self.session.get(test_url, timeout=15, allow_redirects=True)
@@ -198,6 +224,16 @@ class WebVPNAuth:
         return False
 
     def _browser_login(self) -> bool:
+        # Fail BEFORE launching any browser: launching and then bailing out
+        # leaks the sync Playwright dispatcher loop on this thread, and every
+        # later launch then dies with "Playwright Sync API inside the asyncio
+        # loop" for the rest of the process (seen in CLI fetch/batch).
+        if not self._webvpn_base:
+            logger.error(
+                "WebVPN base URL is empty — school gateway unknown. "
+                "Run `scansci-pdf setup <学校全名>` first and check `scansci-pdf schools`."
+            )
+            return False
         if not _HAS_CLOAKBROWSER:
             logger.error("no browser backend available. Run: pip install patchright (or pip install cloakbrowser)")
             return False
@@ -215,16 +251,10 @@ class WebVPNAuth:
             self._page = self._context.new_page()
         except Exception as e:
             logger.error("Failed to start CloakBrowser: %s", e)
+            self._close_browser_quietly()
             return False
 
         _seed_saved_cookies(_get_cookie_path(self.config), self._context)
-
-        if not self._webvpn_base:
-            logger.error(
-                "WebVPN base URL is empty — school gateway unknown. "
-                "Run `scansci-pdf setup <学校全名>` first and check `scansci-pdf schools`."
-            )
-            return False
 
         self._page.goto(self._webvpn_base, wait_until="networkidle", timeout=30000)
         current_url = self._page.url

--- a/src/scansci_pdf/fetcher.py
+++ b/src/scansci_pdf/fetcher.py
@@ -184,12 +184,24 @@ class PaperFetcher:
     def auth(self) -> WebVPNAuth | EZProxyAuth:
         if self._auth is None:
             from .schools import get_school
-            school_name = self.config.get("instsci_school", "")
+            school_name = (self.config.get("instsci_school", "")
+                           or self.config.get("vpnsci_school", "")).strip()
+            if not school_name:
+                # Raised deliberately: fetch_with_result() converts ValueError
+                # into a structured config_needed outcome. get_school("") would
+                # otherwise fuzzy-match an arbitrary school and the cascade
+                # would navigate to a garbage/empty gateway URL.
+                raise ValueError(
+                    "no institution configured (instsci_school/vpnsci_school are empty)"
+                )
             entry = get_school(school_name)
             if entry.school_type == "ezproxy":
                 self._auth = EZProxyAuth(self.config, proxy_base=entry.host)
             else:
-                self._auth = WebVPNAuth(self.config, key=entry.key, iv=entry.iv)
+                # Fall back to the school database gateway host when no
+                # explicit base URL is configured.
+                self._auth = WebVPNAuth(self.config, key=entry.key, iv=entry.iv,
+                                        base_url=getattr(entry, "host", "") or "")
         return self._auth
 
     def fetch(self, identifier: str, use_cache: bool = True) -> Paper:

--- a/src/scansci_pdf/institutional/instsci_bridge.py
+++ b/src/scansci_pdf/institutional/instsci_bridge.py
@@ -466,6 +466,16 @@ def _try_elsevier_api(
     try:
         resp = requests.get(url, headers=headers, timeout=30)
         if resp.status_code == 200 and resp.content[:5] == b"%PDF-":
+            # A valid API key without full-text entitlement still returns a
+            # 1-page preview PDF (often >100KB). Accepting it poisons the
+            # result and the download cache with a fake success.
+            try:
+                from ..sources.elsevier_api import _pdf_page_count
+                if _pdf_page_count(resp.content) == 1:
+                    log.info(f"   [Institutional] Elsevier API: 1-page preview (not entitled) for {doi}")
+                    return None
+            except ImportError:
+                pass
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(resp.content)
             if output_path.exists() and output_path.stat().st_size > 5000:

--- a/src/scansci_pdf/institutional/sources/elsevier_api.py
+++ b/src/scansci_pdf/institutional/sources/elsevier_api.py
@@ -63,6 +63,15 @@ def fetch_pdf(doi: str, api_key: str, inst_token: str = "") -> bytes | None:
         logger.warning("Elsevier API returned suspiciously small PDF (%d bytes)", len(resp.content))
         return None
 
+    # Reject 1-page previews served to API keys without full-text entitlement
+    try:
+        from ...sources.elsevier_api import _pdf_page_count
+        if _pdf_page_count(resp.content) == 1:
+            logger.info("Elsevier API returned a 1-page preview — treating as no entitlement")
+            return None
+    except ImportError:
+        pass
+
     logger.info("Elsevier API: downloaded %d bytes for %s", len(resp.content), doi)
     return resp.content
 

--- a/src/scansci_pdf/main.py
+++ b/src/scansci_pdf/main.py
@@ -154,7 +154,9 @@ def get_paper(
             for f in si_files:
                 print(f"    {f}")
     else:
-        print(f"  FAILED: {result.get('error', 'unknown')}")
+        reason = (result.get("reason") or result.get("error")
+                  or result.get("error_type") or "unknown")
+        print(f"  FAILED: {reason}")
         hint = result.get('agent_hint', '')
         if hint:
             print(f"  Hint: {hint}")

--- a/src/scansci_pdf/pdf_utils.py
+++ b/src/scansci_pdf/pdf_utils.py
@@ -66,27 +66,32 @@ def _response_looks_pdf(resp: requests.Response, first_chunk: bytes) -> bool:
 def is_suspicious_pdf(path: Path) -> bool:
     """Check if a PDF looks like a cover page or preview (not full text).
 
-    Heuristics (all must match to be suspicious):
+    Heuristics:
       - Very small file (< 50 KB): likely a 1-page cover
-      - Has at most 1 page: preview/cover page
+      - At most 1 readable page: preview/cover page. File size alone is NOT
+        trusted — Elsevier serves >100KB single-page previews to API keys
+        without full-text entitlement.
     """
     try:
         size = path.stat().st_size
-        # Large files (> 100KB) are almost certainly full text
-        if size > 100_000:
-            return False
         # Very small files are suspicious regardless
         if size < 50_000:
             return True
-        # For files between 50KB-100KB, check page count
-        with path.open("rb") as fh:
-            content = fh.read(512_000)
-        # Count PDF page objects: look for "/Type /Page" not followed by "s"
-        import re
-        pages = len(re.findall(rb"/Type\s*/Page\b", content))
-        if pages <= 1:
-            return True
-        return False
+        try:
+            import fitz  # type: ignore[import-not-found]
+        except Exception:
+            # No pymupdf: fall back to the cheap regex heuristic
+            with path.open("rb") as fh:
+                content = fh.read(512_000)
+            # Count PDF page objects: look for "/Type /Page" not followed by "s"
+            import re
+            pages = len(re.findall(rb"/Type\s*/Page\b", content))
+            return pages <= 1
+        try:
+            with fitz.open(path) as doc:
+                return int(doc.page_count) <= 1
+        except Exception:
+            return True  # unreadable PDF — treat as suspicious
     except OSError:
         return False
 

--- a/src/scansci_pdf/sources/__init__.py
+++ b/src/scansci_pdf/sources/__init__.py
@@ -718,7 +718,58 @@ def _auto_rename(result: dict[str, Any], identifier: str, config: dict[str, Any]
         log.info(f"   No metadata for rename, keeping: {file_path.name}")
 
 
+# Single-flight guard: at most one download() per identifier per process.
+# Duplicate submissions (e.g. an MCP client retrying after its own 30s client
+# timeout while the server is still racing sources) used to start a second,
+# parallel browser task for the same paper — the "infinite popup" experience.
+_INFLIGHT_LOCK = threading.Lock()
+_INFLIGHT: set[str] = set()
+
+
 def download(
+    identifier: str,
+    output_dir: str | Path | None = None,
+    *,
+    scihub_enabled: bool | None = None,
+    use_tor: bool = False,
+    use_vpnsci: bool = False,
+    bibtex: bool = False,
+    rename: bool = True,
+    _institutional: bool = True,
+    strategy: str | None = None,
+) -> dict[str, Any]:
+    key = identifier.strip()
+    if not is_arxiv_identifier(key):
+        key = normalize_doi(key)
+    with _INFLIGHT_LOCK:
+        if key in _INFLIGHT:
+            log.info(f"   Single-flight: download already in progress for {key}")
+            return fail(
+                key,
+                reason="download already in progress for this identifier",
+                error_type="in_progress",
+                action="wait for the in-flight attempt to finish (it is still "
+                       "racing sources); retry in a minute only if it failed",
+            )
+        _INFLIGHT.add(key)
+    try:
+        return _download_impl(
+            identifier,
+            output_dir,
+            scihub_enabled=scihub_enabled,
+            use_tor=use_tor,
+            use_vpnsci=use_vpnsci,
+            bibtex=bibtex,
+            rename=rename,
+            _institutional=_institutional,
+            strategy=strategy,
+        )
+    finally:
+        with _INFLIGHT_LOCK:
+            _INFLIGHT.discard(key)
+
+
+def _download_impl(
     identifier: str,
     output_dir: str | Path | None = None,
     *,

--- a/src/scansci_pdf/sources/scihub.py
+++ b/src/scansci_pdf/sources/scihub.py
@@ -125,6 +125,13 @@ _WALL_COOLDOWN_BASE_SEC = 90.0   # first persistent-wall cooldown
 _WALL_COOLDOWN_CAP_SEC = 900.0   # never cool down longer than this
 _MIRROR_STRUCTURAL_COOLDOWN_SEC = 7200.0  # structurally broken mirror: skip 2h
 
+# Serialize INTERACTIVE Turnstile solving across pool workers. Each pool
+# worker owns a browser, so without this lock N workers hitting a gate open N
+# "please click the captcha" windows at once. Queued workers re-check after
+# the first solve; the clearance cookie is shared per domain, so they usually
+# pass without a new human challenge.
+_TURNSTILE_INTERACTIVE_LOCK = threading.Lock()
+
 
 def _wall_guard(domain: str, config: dict[str, Any]) -> bool:
     """True while a domain is cooling down after persistent walls — skip it.
@@ -404,8 +411,14 @@ def _browser_first_download(
     doi: str,
     output_path: Path,
     config: dict[str, Any],
+    fail_notes: list[str] | None = None,
 ) -> dict[str, Any] | None:
-    """Try browser-first download for Sci-Hub. Bypasses Cloudflare/CAPTCHA."""
+    """Try browser-first download for Sci-Hub. Bypasses Cloudflare/CAPTCHA.
+
+    fail_notes (optional): appended with a short classification string at
+    every failure exit so callers can report WHY Sci-Hub gave up
+    (not_in_library / challenge_* / network / http_*).
+    """
     try:
         from ..browser_engine import solve_url, download_pdf_via_browser
         from ..pdf_utils import is_pdf_file, success, extract_pdf_url_from_html
@@ -416,18 +429,24 @@ def _browser_first_download(
         result = solve_url(landing_url, config, max_timeout=30000)
         if not result:
             log.info(f"   [browser-first] no response")
+            if fail_notes is not None:
+                fail_notes.append("network(no response)")
             return None
 
         solution = result.get("solution", {})
         html = solution.get("response", "")
         if not html:
             log.info(f"   [browser-first] empty response")
+            if fail_notes is not None:
+                fail_notes.append("network(empty response)")
             return None
 
         # Check for article not found
         lower = html.lower()
         if any(sig in lower for sig in ["article not found", "статья не найдена", "не найден"]):
             log.info(f"   [browser-first] article not found on {domain}")
+            if fail_notes is not None:
+                fail_notes.append("not_in_library")
             return None
 
         # Structural failures: mirror shell or interactive gate. These cost a
@@ -436,6 +455,8 @@ def _browser_first_download(
         if kind == "homepage":
             _note_structural(domain, config)
             log.info(f"   [browser-first] {domain} serves its homepage shell — structural, cooling down")
+            if fail_notes is not None:
+                fail_notes.append("structural_homepage")
             return None
         if kind == "turnstile":
             if _racing_browser_headless(config) or not config.get("scihub_turnstile_click", True):
@@ -444,44 +465,48 @@ def _browser_first_download(
                 return None
             # Interactive mode: surface it on the progress bar, wait for one
             # human click. The clearance cookie then lasts the whole batch.
-            from ..browser_engine import get_browser_page
-            page = get_browser_page(config)
-            if page is None:
-                _note_structural(domain, config)
-                return None
-            attention_key = f"turnstile:{domain}"
-            try:
-                from .. import progress_reporter as _pr
-                _pr.set_attention(attention_key, "请在浏览器窗口完成 Turnstile 人机验证",
-                                  current=doi, phase="人工验证")
-            except Exception:
-                _pr = None
-            passed = False
-            try:
-                deadline = time.time() + max(30, int(config.get("turnstile_wait_sec", 180)))
-                while time.time() < deadline:
-                    time.sleep(5)
-                    page.goto(landing_url, wait_until="domcontentloaded", timeout=30000)
-                    html = page.content()
-                    if _classify_mirror_page(html) != "turnstile":
-                        passed = True
-                        break
-                if not passed:
-                    log.info(f"   [browser-first] Turnstile not passed within wait window")
+            # Serialized across pool workers — see _TURNSTILE_INTERACTIVE_LOCK.
+            with _TURNSTILE_INTERACTIVE_LOCK:
+                from ..browser_engine import get_browser_page
+                page = get_browser_page(config)
+                if page is None:
+                    _note_structural(domain, config)
                     return None
-                solution["url"] = page.url
-                log.info(f"   [browser-first] Turnstile cleared by human — cookie kept for the batch")
-            finally:
-                if _pr is not None:
+                attention_key = f"turnstile:{domain}"
+                try:
+                    from .. import progress_reporter as _pr
+                    _pr.set_attention(attention_key, "请在浏览器窗口完成 Turnstile 人机验证",
+                                      current=doi, phase="人工验证")
+                except Exception:
+                    _pr = None
+                passed = False
+                try:
+                    deadline = time.time() + max(30, int(config.get("turnstile_wait_sec", 180)))
+                    while time.time() < deadline:
+                        time.sleep(5)
+                        page.goto(landing_url, wait_until="domcontentloaded", timeout=30000)
+                        html = page.content()
+                        if _classify_mirror_page(html) != "turnstile":
+                            passed = True
+                            break
+                    if not passed:
+                        log.info(f"   [browser-first] Turnstile not passed within wait window")
+                        if fail_notes is not None:
+                            fail_notes.append("challenge_turnstile_timeout")
+                        return None
+                    solution["url"] = page.url
+                    log.info(f"   [browser-first] Turnstile cleared by human — cookie kept for the batch")
+                finally:
+                    if _pr is not None:
+                        try:
+                            _pr.clear_attention(attention_key)
+                        except Exception:
+                            pass
                     try:
-                        _pr.clear_attention(attention_key)
+                        page.close()
                     except Exception:
                         pass
-                try:
-                    page.close()
-                except Exception:
-                    pass
-            lower = html.lower()
+                lower = html.lower()
 
         # Check for ALTCHA anti-bot verification (used by sci-hub.ru and other mirrors)
         if any(sig in lower for sig in ["altcha", "你是机器人吗", "not a robot"]):
@@ -498,11 +523,15 @@ def _browser_first_download(
             log.info(f"   [browser-first] Cloudflare challenge on {domain}, page may need more time")
             # The solve_url should have waited, but if we still see the challenge,
             # mark this domain as needing browser bypass for future attempts
+            if fail_notes is not None:
+                fail_notes.append("challenge_cloudflare")
             return None
 
         # Check for empty embed (Sci-Hub has no PDF)
         if '<embed' in lower and 'src=""' in lower:
             log.info(f"   [browser-first] empty embed — article not in Sci-Hub database")
+            if fail_notes is not None:
+                fail_notes.append("not_in_library")
             return None
 
         # Extract PDF URL from HTML
@@ -533,9 +562,13 @@ def _browser_first_download(
                 pass
 
         log.info(f"   [browser-first] no PDF found in response")
+        if fail_notes is not None:
+            fail_notes.append("not_in_library(no pdf in response)")
         return None
     except Exception as e:
         log.info(f"   [browser-first] error: {e}")
+        if fail_notes is not None:
+            fail_notes.append(f"network({type(e).__name__})")
         return None
 
 
@@ -545,12 +578,14 @@ def try_scihub_domain(
     output_path: Path,
     config: dict[str, Any],
     use_tor: bool = False,
+    fail_notes: list[str] | None = None,
 ) -> dict[str, Any] | None:
     landing_url = f"{domain.rstrip('/')}/{urllib.parse.quote(doi, safe='/')}"
 
     # Browser-first: bypass Cloudflare/CAPTCHA before HTTP attempt
     if _is_browser_available(config):
-        result = _browser_first_download(landing_url, doi, output_path, config)
+        result = _browser_first_download(landing_url, doi, output_path, config,
+                                         fail_notes=fail_notes)
         if result:
             return result
 
@@ -562,9 +597,13 @@ def try_scihub_domain(
             _mark_browser_required(domain, config)
             resp = _try_browser(landing_url, config, resp)
             if resp is None:
+                if fail_notes is not None:
+                    fail_notes.append("challenge(browser bypass failed)")
                 return None
 
         if resp.status_code >= 400:
+            if fail_notes is not None:
+                fail_notes.append(f"http_{resp.status_code}")
             return None
 
         first = next(resp.iter_content(chunk_size=8192), b"")
@@ -577,6 +616,8 @@ def try_scihub_domain(
                 browser_resp = _try_browser(landing_url, config, resp)
                 if browser_resp is None:
                     log.warning(f"   browser bypass failed — is CloakBrowser installed? Run: pip install cloakbrowser")
+                    if fail_notes is not None:
+                        fail_notes.append("challenge(captcha bypass failed)")
                     return None
                 # Get new content from browser response
                 resp = browser_resp
@@ -609,13 +650,19 @@ def try_scihub_domain(
                 html = first
         pdf_url = extract_pdf_url_from_html(html.decode("utf-8", errors="ignore"), resp.url)
         if not pdf_url:
+            if fail_notes is not None:
+                fail_notes.append("not_in_library(no pdf url)")
             return None
         result = download_pdf_from_scihub(pdf_url, output_path, config, f"Sci-Hub({domain})", use_tor=use_tor, cookies=resp.cookies)
         if result:
             result["doi"] = doi
             result["identifier"] = doi
+        elif fail_notes is not None:
+            fail_notes.append("not_in_library(pdf download failed)")
         return result
-    except Exception:
+    except Exception as e:
+        if fail_notes is not None:
+            fail_notes.append(f"network({type(e).__name__})")
         return None
 
 
@@ -861,6 +908,7 @@ def _try_scihub_impl(doi: str, output_path: Path, config: dict[str, Any], use_to
     _failure_reason = "all domains unreachable"
     _any_reachable = False
     _any_browser_tried = False
+    fail_notes: list[str] = []
 
 
     if _HAS_COMPILED_CORE:
@@ -913,7 +961,8 @@ def _try_scihub_impl(doi: str, output_path: Path, config: dict[str, Any], use_to
 
     if len(domains) == 1:
         try:
-            result = try_scihub_domain(doi, domains[0], output_path, config, use_tor=use_tor)
+            result = try_scihub_domain(doi, domains[0], output_path, config, use_tor=use_tor,
+                                       fail_notes=fail_notes)
             if result:
                 record_result(domains[0], True, config)
                 return result
@@ -929,7 +978,7 @@ def _try_scihub_impl(doi: str, output_path: Path, config: dict[str, Any], use_to
     log.info(f"   Sci-Hub: trying {best_domain} first...")
     try:
         result = _race_pool(config).submit(
-            try_scihub_domain, doi, best_domain, best_output, config, use_tor
+            try_scihub_domain, doi, best_domain, best_output, config, use_tor, fail_notes
         ).result()
         if result and result.get("success"):
             final_path = Path(result.get("file", ""))
@@ -959,7 +1008,7 @@ def _try_scihub_impl(doi: str, output_path: Path, config: dict[str, Any], use_to
     futures = {}
     for domain in remaining:
         src_output = output_path.parent / f"{output_path.stem}_scihub_{domain.split('//')[1].replace('.', '_')}.pdf"
-        futures[pool.submit(try_scihub_domain, doi, domain, src_output, config, use_tor)] = (domain, src_output)
+        futures[pool.submit(try_scihub_domain, doi, domain, src_output, config, use_tor, fail_notes)] = (domain, src_output)
     try:
         for future in as_completed(futures, timeout=10):
             domain, src_output = futures[future]
@@ -1005,5 +1054,10 @@ def _try_scihub_impl(doi: str, output_path: Path, config: dict[str, Any], use_to
         log.info("   Sci-Hub: all clearnet domains failed, retrying via Tor...")
         return try_scihub(doi, output_path, config, use_tor=True)
 
-    log.warning(f"   Sci-Hub: all domains failed for {doi}. Check: 1) network connectivity 2) Tor status (scansci-pdf tor_start)")
+    if fail_notes:
+        from collections import Counter
+        summary = ", ".join(f"{k}×{v}" for k, v in Counter(fail_notes).most_common())
+        log.warning(f"   Sci-Hub: all domains failed for {doi} ({summary})")
+    else:
+        log.warning(f"   Sci-Hub: all domains failed for {doi}. Check: 1) network connectivity 2) Tor status (scansci-pdf tor_start)")
     return None

--- a/tests/test_batch_termination.py
+++ b/tests/test_batch_termination.py
@@ -23,8 +23,20 @@ def _make_source(delay: float, ok: bool, label: str):
         time.sleep(delay)
         if not ok:
             return {"success": False, "error": "simulated failure", "source": label_}
-        # >100KB so is_suspicious_pdf (size heuristic) does not flag it
-        out_path.write_bytes(b"%PDF-1.4 fake" + b"0" * 150_000)
+        # A real multi-page PDF padded >100KB: is_suspicious_pdf now uses the
+        # actual page count (single-page previews are rejected), so the fake
+        # must be a parseable multi-page document to count as full text.
+        import os as _os
+        import fitz as _fitz
+        doc = _fitz.open()
+        for _i in range(3):
+            _page = doc.new_page()
+            _page.insert_text((72, 72), f"Fake full text page {_i + 1}")
+        _blob = _os.urandom(120_000)
+        _xref = doc.get_new_xref()
+        doc.update_object(_xref, f"<< /Type /EmbeddedFile /Length {len(_blob)} >>")
+        doc.update_stream(_xref, _blob, compress=False)
+        out_path.write_bytes(doc.tobytes())
         return {"success": True, "file": str(out_path), "source": label_}
     return src
 

--- a/tests/test_preview_guard.py
+++ b/tests/test_preview_guard.py
@@ -1,0 +1,103 @@
+"""Regression tests: Elsevier 1-page previews must never pass as full text."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import fitz
+import pytest
+
+
+def _make_pdf(pages: int, min_size: int = 0) -> bytes:
+    """Build an in-memory PDF with `pages` pages, padded above min_size bytes.
+
+    Padding uses an uncompressed embedded stream (incompressible random
+    bytes), so size-based heuristics (>50KB / >100KB) are genuinely exercised.
+    """
+    doc = fitz.open()
+    for i in range(pages):
+        page = doc.new_page()
+        page.insert_text((72, 72), f"Test document page {i + 1}")
+    if min_size and len(doc.tobytes()) < min_size:
+        blob = os.urandom(min_size)
+        xref = doc.get_new_xref()
+        doc.update_object(xref, f"<< /Type /EmbeddedFile /Length {len(blob)} >>")
+        doc.update_stream(xref, blob, compress=False)
+    data = doc.tobytes()
+    if min_size:
+        assert len(data) >= min_size, f"padding failed: {len(data)} < {min_size}"
+    return data
+
+
+class TestIsSuspiciousPdf:
+    def test_large_single_page_is_suspicious(self, tmp_path: Path):
+        """The core regression: a >100KB 1-page Elsevier preview used to pass
+        because is_suspicious_pdf exempted large files outright."""
+        p = tmp_path / "preview.pdf"
+        p.write_bytes(_make_pdf(1, min_size=150_000))
+        assert p.stat().st_size > 100_000
+        from scansci_pdf.pdf_utils import is_suspicious_pdf
+        assert is_suspicious_pdf(p) is True
+
+    def test_large_multi_page_is_not_suspicious(self, tmp_path: Path):
+        p = tmp_path / "full.pdf"
+        p.write_bytes(_make_pdf(3, min_size=150_000))
+        from scansci_pdf.pdf_utils import is_suspicious_pdf
+        assert is_suspicious_pdf(p) is False
+
+    def test_small_file_is_suspicious(self, tmp_path: Path):
+        p = tmp_path / "cover.pdf"
+        p.write_bytes(_make_pdf(1))
+        from scansci_pdf.pdf_utils import is_suspicious_pdf
+        assert is_suspicious_pdf(p) is True
+
+
+class TestInstsciElsevierPreview:
+    def test_try_elsevier_api_rejects_single_page_preview(self, tmp_path: Path):
+        from scansci_pdf.institutional import instsci_bridge
+
+        class _Resp:
+            status_code = 200
+            content = _make_pdf(1, min_size=150_000)
+
+        out = tmp_path / "10.1016_j.fake.1.pdf"
+        with patch("requests.get", return_value=_Resp()):
+            result = instsci_bridge._try_elsevier_api(
+                "10.1016/j.fake.1", out, {"elsevier_api_key": "k"}
+            )
+        assert result is None
+        assert not out.exists(), "preview bytes must not be written to disk"
+
+    def test_try_elsevier_api_accepts_full_text(self, tmp_path: Path):
+        from scansci_pdf.institutional import instsci_bridge
+
+        class _Resp:
+            status_code = 200
+            content = _make_pdf(5, min_size=150_000)
+
+        out = tmp_path / "10.1016_j.fake.2.pdf"
+        with patch("requests.get", return_value=_Resp()):
+            result = instsci_bridge._try_elsevier_api(
+                "10.1016/j.fake.2", out, {"elsevier_api_key": "k"}
+            )
+        assert result is not None and result["success"] is True
+        assert result["source"] == "institutional:elsevier_api"
+
+    def test_institutional_fetch_pdf_rejects_single_page(self):
+        """The second institutional Elsevier PDF path must reject previews too."""
+        from scansci_pdf.institutional.sources import elsevier_api as inst_api
+
+        assert inst_api.fetch_pdf("10.1016/j.fake.3", "k") is None
+
+
+class TestRacingElsevierPreview:
+    def test_valid_pdf_bytes_rejects_single_page(self):
+        from scansci_pdf.sources.elsevier_api import _valid_pdf_bytes
+
+        assert _valid_pdf_bytes(_make_pdf(1, min_size=150_000), "t", reject_single_page=True) is False
+        assert _valid_pdf_bytes(_make_pdf(4, min_size=150_000), "t", reject_single_page=True) is True
+        assert _valid_pdf_bytes(_make_pdf(1, min_size=150_000), "t", reject_single_page=False) is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_webvpn_auth.py
+++ b/tests/test_webvpn_auth.py
@@ -1,0 +1,51 @@
+"""Regression tests: WebVPN auth must fail fast and never leak a Playwright loop."""
+
+import pytest
+
+from scansci_pdf.auth import WebVPNAuth
+
+
+CFG = {"instsci_school": "", "vpnsci_school": "", "instsci_base_url": "",
+       "vpnsci_base_url": ""}
+
+
+class TestConvertUrlEmptyBase:
+    def test_convert_url_raises_on_empty_base(self):
+        """Used to return '/https/77726476...' — a relative URL that callers
+        then navigated to as 'Cannot navigate to invalid URL'."""
+        auth = WebVPNAuth(dict(CFG))
+        with pytest.raises(ValueError):
+            auth.convert_url("https://example.com/article/pii/X")
+
+    def test_validate_session_false_when_no_base(self):
+        auth = WebVPNAuth(dict(CFG))
+        assert auth._validate_session() is False
+
+    def test_convert_url_ok_with_base(self):
+        auth = WebVPNAuth(dict(CFG), base_url="https://webvpn.example.edu.cn")
+        url = auth.convert_url("https://www.sciencedirect.com/x")
+        assert url.startswith("https://webvpn.example.edu.cn/https/")
+        assert "77726476706e69737468656265737421" in url  # default IV hex prefix
+
+
+class TestBrowserLoginFailFast:
+    def test_no_browser_launched_when_base_empty(self, monkeypatch, tmp_path):
+        """The leak: _browser_login used to launch the persistent context
+        FIRST and only then discover the empty gateway, returning without
+        closing it — poisoning the thread's Playwright loop."""
+        import scansci_pdf.auth as auth_mod
+
+        launched = []
+
+        def _fake_launch(**kwargs):
+            launched.append(kwargs)
+            raise AssertionError("browser must not be launched when webvpn base is empty")
+
+        monkeypatch.setattr(auth_mod, "_HAS_CLOAKBROWSER", True)
+        monkeypatch.setattr("scansci_pdf.browser_backend.launch_persistent_context", _fake_launch)
+        monkeypatch.setattr(auth_mod, "_get_profile_dir", lambda cfg: tmp_path)
+
+        auth = WebVPNAuth(dict(CFG))
+        assert auth._browser_login() is False
+        assert launched == []
+        assert auth._context is None


### PR DESCRIPTION
## Summary

Three reliability fixes found while downloading a 12-DOI batch on Windows 11 (scansci-pdf 1.14.0 via uv tool + MCP), each with a reproducible log trace.

### 1. Elsevier 1-page preview accepted as a successful download (cache poisoning)

With a valid API key but no full-text entitlement (off-campus), `GET /content/article/doi/{doi}` with `Accept: application/pdf` returns a **1-page preview PDF, often >100KB**. The institutional bridge accepted it:

```
[INFO] Elsevier API: direct PDF is a 1-page preview        <- racing lane rejects
{"source": "institutional:elsevier_api", "success": true}  <- bridge accepts, 1 page
```

The fake success was then written to `.doi_index.json` + cache (TTL 168h), so **every retry for 7 days returned the same 1-page file** even after the user fixed the underlying cause. Repro: any paywalled Elsevier DOI while not entitled.

Fix: page-count check (`fitz`) before accepting PDF bytes in
- `institutional/instsci_bridge.py::_try_elsevier_api`
- `institutional/sources/elsevier_api.py::fetch_pdf`
- `pdf_utils.py::is_suspicious_pdf` — drop the unconditional `>100KB → not suspicious` exemption (previews are image-heavy and large); use real page count, regex fallback only when pymupdf is missing.

### 2. Sci-Hub interactive-popup storm

Three stacked causes, all hit in one session:

a. `scihub_browser_workers: 3` — each persistent pool worker owns a browser; a Turnstile gate therefore opened **3 verification windows at once**.
b. **No per-DOI single-flight**: MCP clients time out client-side (~30s) while the server keeps racing; the natural retry started a *second* parallel browser task for the same DOI → windows kept stacking.
c. Nothing classified failures, so "not in library" vs "blocked" vs "network" were indistinguishable (`FAILED: unknown` at CLI).

Fix:
- Global `_TURNSTILE_INTERACTIVE_LOCK`: only ONE interactive verification window at a time; queued workers re-check afterwards (clearance cookies are shared, so they usually pass without a new challenge).
- Per-identifier single-flight in `download()` (wrapper over `_download_impl`): duplicate submissions return `error_type="in_progress"` with an action hint instead of launching a second browser.
- `try_scihub_domain` / `_browser_first_download` accept an optional `fail_notes` list, classify each failure exit (`not_in_library`, `challenge_*`, `http_*`, `network(*)`), and the final warning prints a tally, e.g. `all domains failed for 10.x/y (not_in_library×2, challenge_turnstile_timeout×1)`.
- CLI `get` now prints `reason`/`error_type` instead of the always-`unknown` `error` key (`main.py`).

### 3. WebVPN cascade: leaked Playwright loop + garbage gateway URLs

Observed in CLI `fetch`/`batch` with no institution configured:

```
[INFO] All saved cookies have expired.
[ERROR] WebVPN base URL is empty — school gateway unknown.
[INFO] Browser: navigating to article page /https/77726476706e697374...  <- relative URL from convert_url()
[WARNING] Navigation failed: Cannot navigate to invalid URL
[ERROR] Failed to start CloakBrowser: It looks like you are using Playwright Sync API inside the asyncio loop.
```

Root cause chain: `_browser_login()` launched the persistent context **before** checking that the WebVPN base URL existed, then returned `False` without closing it. The leaked sync Playwright dispatcher loop poisoned the main thread, so every later browser launch in the same process died with the asyncio error. Additionally, `convert_url()` returned a relative `/https/77726476...` URL when the base was empty (the `77726476706e69737468656265737421` prefix is the default IV `wrdvpnisthebest!` in hex), and `get_school("")` fuzzy-matched the empty string against every school and returned the shortest name.

Fix:
- `_browser_login()` validates the gateway **before** launching any browser.
- `convert_url()` raises `ValueError` on empty base instead of returning a garbage relative URL; `_validate_session()` pre-checks.
- `_browser_login()` closes the context on any post-launch failure (`_close_browser_quietly()`).
- `PaperFetcher.auth` raises `ValueError` when no school is configured (already converted to a structured `config_needed / institution_not_configured` result by `fetch_with_result`), and falls back to the school-database gateway host when only `instsci_school`/`vpnsci_school` is set (`WebVPNAuth(base_url=entry.host)`).

## Tests

- `tests/test_preview_guard.py` — synthetic >100KB 1-page and multi-page PDFs (padded via an uncompressed embedded stream): `is_suspicious_pdf` page-count behavior; `_try_elsevier_api` rejects previews without writing bytes to disk; both Elsevier PDF paths.
- `tests/test_webvpn_auth.py` — `convert_url` raises on empty base; `_validate_session` returns False; `_browser_login` does not launch any browser when the gateway is unconfigured.

## Future work (discussed, not in this PR)

- MCP tool-level job status query / longer client timeouts (clients currently retry blindly after their own timeout).
- Job queue for batch institutional phase; CLI async-safety refactor beyond the loop-leak fix.
- Distinguish "DOI not present on Sci-Hub" from "domain blocked" in the JSON failure reason (partially addressed by fail_notes).

## Environment

Windows 11, Python 3.12.13 (uv tool venv), scansci-pdf 1.14.0, patchright backend, Chrome 126.
